### PR TITLE
Bugfix: backwards compatibility for fastify 0.x.

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = async function (fastify, opts) {
   fastify.all('/*', { beforeHandler }, reply)
 
   function reply (request, reply) {
-    var dest = request.raw.url.replace(this.basePath, '')
+    var dest = request.req.url.replace(this.basePath, '')
     reply.from(dest)
   }
 }


### PR DESCRIPTION
Changed `request.raw` to `request.req` in order to provide backwards compatibility for pre-v1 versions of Fastify.