### PR TITLE
feat: support reply options

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ The prefix to mount this plugin on. All the requests to the current server start
 
 A `beforeHandler` to be applied on all routes. Useful for performing actions before the proxy is executed (e.g. check for authentication).
 
+### replyOptions
+
+Object with [reply options](https://github.com/fastify/fastify-reply-from#replyfromsource-opts) for `fastify-reply-from`.
+
 ## Benchmarks
 
 The following benchmarks where generated on a Macbook 2018 with i5 and

--- a/index.js
+++ b/index.js
@@ -27,6 +27,6 @@ module.exports = async function (fastify, opts) {
 
   function reply (request, reply) {
     var dest = request.req.url.replace(this.basePath, '')
-    reply.from(dest || '/')
+    reply.from(dest || '/', opts.replyOptions)
   }
 }

--- a/test.js
+++ b/test.js
@@ -160,14 +160,6 @@ async function run () {
   })
 
   test('passes replyOptions object to reply.from() calls', async (t) => {
-    const server = Fastify()
-
-    server.get('/', async (request, reply) => {
-      return 'this is root for server'
-    })
-
-    await server.listen(0)
-
     const proxyServer = Fastify()
 
     proxyServer.register(proxy, {
@@ -181,7 +173,6 @@ async function run () {
     await proxyServer.listen(0)
 
     t.tearDown(() => {
-      server.close()
       proxyServer.close()
     })
 

--- a/test.js
+++ b/test.js
@@ -158,6 +158,36 @@ async function run () {
     const secondProxyPrefix = await got(`http://localhost:${proxyServer.server.address().port}/api2`)
     t.equal(secondProxyPrefix.body, 'this is root for origin2')
   })
+
+  test('passes replyOptions object to reply.from() calls', async (t) => {
+    const server = Fastify()
+
+    server.get('/', async (request, reply) => {
+      return 'this is root for server'
+    })
+
+    await server.listen(0)
+
+    const proxyServer = Fastify()
+
+    proxyServer.register(proxy, {
+      upstream: `http://localhost:${origin.server.address().port}`,
+      prefix: '/api',
+      replyOptions: {
+        rewriteHeaders: headers => Object.assign({ 'x-test': 'test' }, headers)
+      }
+    })
+
+    await proxyServer.listen(0)
+
+    t.tearDown(() => {
+      server.close()
+      proxyServer.close()
+    })
+
+    const { headers } = await got(`http://localhost:${proxyServer.server.address().port}/api`)
+    t.match(headers, { 'x-test': 'test' })
+  })
 }
 
 run()


### PR DESCRIPTION
Adds support for `rewriteHeaders`, `onResponse`, `queryString` and other options from fastify-reply-from 
https://github.com/fastify/fastify-reply-from#replyfromsource-opts