### PR TITLE
Fix typo in object assign for replyOptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = async function (fastify, opts) {
   fromOpts.prefix = undefined
 
   const oldRewriteHeaders = (opts.replyOptions || {}).rewriteHeaders
-  const replyOpts = Object.assign({}, opts.replyOpts, {
+  const replyOpts = Object.assign({}, opts.replyOptions, {
     rewriteHeaders
   })
   fromOpts.rewriteHeaders = rewriteHeaders


### PR DESCRIPTION
I believe this will fix my issue here: https://github.com/fastify/fastify-http-proxy/issues/33 

As far as I can tell this just breaks because the wrong variable is used in the `Object.assign` let me know if this seems valid. Tests passed locally for me. 

If you need any changes let me know. 