### PR TITLE
Replace basePath with prefix for Fastify v2 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This plugin can be used in a variety of circumstances, for example if you have t
 
 ## Requirements
 
-Fastify ^1.8.0
+Fastify 2.x. See [this branch](https://github.com/fastify/fastify-http-proxy/tree/1.x) and related versions for Fastify 1.x compatibility.
 
 ## Install
 

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports = async function (fastify, opts) {
   function rewriteHeaders (headers) {
     const location = headers.location
     if (location) {
-      headers.location = location.replace(rewritePrefix, fastify.basePath)
+      headers.location = location.replace(rewritePrefix, fastify.prefix)
     }
     if (oldRewriteHeaders) {
       headers = oldRewriteHeaders(headers)
@@ -45,7 +45,7 @@ module.exports = async function (fastify, opts) {
 
   function reply (request, reply) {
     var dest = request.req.url
-    dest = dest.replace(this.basePath, rewritePrefix)
+    dest = dest.replace(this.prefix, rewritePrefix)
     reply.from(dest || '/', replyOpts)
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "express": "^4.16.4",
     "express-http-proxy": "^1.5.0",
-    "fastify": "^1.13.3",
+    "fastify": "^2.0.0-rc.4",
     "got": "^9.5.0",
     "http-errors": "^1.7.1",
     "http-proxy": "^1.17.0",
@@ -36,7 +36,7 @@
     "tap": "^12.1.1"
   },
   "peerDependencies": {
-    "fastify": "1.x"
+    "fastify": "2.x"
   },
   "dependencies": {
     "fastify-reply-from": "^0.5.3"


### PR DESCRIPTION
Follow up to https://github.com/fastify/fastify-http-proxy/pull/31:
Rebased on master with feedback