### PR TITLE
replace beforeHandler with preHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ request.
 
 Rewrite the prefix to the specified string. Default: `''`.
 
-### beforeHandler
+### preHandler
 
-A `beforeHandler` to be applied on all routes. Useful for performing actions before the proxy is executed (e.g. check for authentication).
+A `preHandler` to be applied on all routes. Useful for performing actions before the proxy is executed (e.g. check for authentication).
 
 ### replyOptions
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = async function (fastify, opts) {
     throw new Error('upstream must be specified')
   }
 
-  const beforeHandler = opts.beforeHandler
+  const preHandler = opts.preHandler
   const rewritePrefix = opts.rewritePrefix || ''
 
   const fromOpts = Object.assign({}, opts)
@@ -40,8 +40,8 @@ module.exports = async function (fastify, opts) {
     done(null, req)
   }
 
-  fastify.all('/', { beforeHandler }, reply)
-  fastify.all('/*', { beforeHandler }, reply)
+  fastify.all('/', { preHandler }, reply)
+  fastify.all('/*', { preHandler }, reply)
 
   function reply (request, reply) {
     var dest = request.req.url

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = async function (fastify, opts) {
     throw new Error('upstream must be specified')
   }
 
-  const preHandler = opts.preHandler
+  const preHandler = opts.preHandler || opts.beforeHandler
   const rewritePrefix = opts.rewritePrefix || ''
 
   const fromOpts = Object.assign({}, opts)

--- a/test.js
+++ b/test.js
@@ -96,11 +96,11 @@ async function run () {
     t.deepEqual(resultRoot.body, { something: 'posted' })
   })
 
-  test('beforeHandler', async (t) => {
+  test('preHandler', async (t) => {
     const server = Fastify()
     server.register(proxy, {
       upstream: `http://localhost:${origin.server.address().port}`,
-      async beforeHandler (request, reply) {
+      async preHandler (request, reply) {
         throw new Unauthorized()
       }
     })

--- a/test.js
+++ b/test.js
@@ -127,6 +127,37 @@ async function run () {
     t.ok(errored)
   })
 
+  test('beforeHandler(deprecated)', async (t) => {
+    const server = Fastify()
+    server.register(proxy, {
+      upstream: `http://localhost:${origin.server.address().port}`,
+      async beforeHandler (request, reply) {
+        throw new Unauthorized()
+      }
+    })
+
+    await server.listen(0)
+    t.tearDown(server.close.bind(server))
+
+    var errored = false
+    try {
+      await got(`http://localhost:${server.server.address().port}`)
+    } catch (err) {
+      t.equal(err.statusCode, 401)
+      errored = true
+    }
+    t.ok(errored)
+
+    errored = false
+    try {
+      await got(`http://localhost:${server.server.address().port}/a`)
+    } catch (err) {
+      t.equal(err.statusCode, 401)
+      errored = true
+    }
+    t.ok(errored)
+  })
+
   test('multiple prefixes with multiple plugins', async (t) => {
     const origin2 = Fastify()
 


### PR DESCRIPTION
Fastify core is complaining Warning: The route option `beforeHandler`
has been deprecated, use `preHandler` instead.
This commit change the `beforeHandler` to `preHandler`