### PR TITLE
Add support for passing in extra configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ A `preHandler` to be applied on all routes. Useful for performing actions before
 
 ### config
 
-An object accessible within the `preHandler` via `reply.context.confg`.
+An object accessible within the `preHandler` via `reply.context.config`.
 See [Config](https://www.fastify.io/docs/v2.1.x/Routes/#config) in the Fastify
 documentation for information on this option. Note: this is merged with other
 configuration passed to the route.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,13 @@ Rewrite the prefix to the specified string. Default: `''`.
 
 A `preHandler` to be applied on all routes. Useful for performing actions before the proxy is executed (e.g. check for authentication).
 
+### config
+
+An object accessible within the `preHandler` via `reply.context.confg`.
+See [Config](https://www.fastify.io/docs/v2.1.x/Routes/#config) in the Fastify
+documentation for information on this option. Note: this is merged with other
+configuration passed to the route.
+
 ### replyOptions
 
 Object with [reply options](https://github.com/fastify/fastify-reply-from#replyfromsource-opts) for `fastify-reply-from`.

--- a/index.js
+++ b/index.js
@@ -40,8 +40,8 @@ module.exports = async function (fastify, opts) {
     done(null, req)
   }
 
-  fastify.all('/', { preHandler }, reply)
-  fastify.all('/*', { preHandler }, reply)
+  fastify.all('/', { preHandler, config: opts.config || {} }, reply)
+  fastify.all('/*', { preHandler, config: opts.config || {} }, reply)
 
   function reply (request, reply) {
     var dest = request.req.url

--- a/test.js
+++ b/test.js
@@ -141,6 +141,30 @@ async function run () {
     t.ok(errored)
   })
 
+  test('preHandler gets config', async t => {
+    const server = Fastify()
+    server.register(proxy, {
+      upstream: `http://localhost:${origin.server.address().port}`,
+      config: { foo: 'bar' },
+      async preHandler (request, reply) {
+        t.deepEqual(reply.context.config, { foo: 'bar', url: '/*' })
+        throw new Unauthorized()
+      }
+    })
+
+    await server.listen(0)
+    t.tearDown(server.close.bind(server))
+
+    var errored = false
+    try {
+      await got(`http://localhost:${server.server.address().port}`)
+    } catch (err) {
+      t.equal(err.statusCode, 401)
+      errored = true
+    }
+    t.ok(errored)
+  })
+
   test('beforeHandler(deprecated)', async t => {
     const server = Fastify()
     server.register(proxy, {


### PR DESCRIPTION
As titled. It is possible that a user may need to pass in context to their `preHandler`. This PR makes it possible.