### PR TITLE
Add tracking `request-id` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,29 @@ Notice that in this case it is important to use the `prefix` option to tell the 
 
 For other examples, see `example.js`.
 
+## Request tracking
+
+`fastify-http-proxy` can track and pipe the `request-id` across the upstreams. Using the [`hyperid`](https://www.npmjs.com/package/hyperid) module and the [`fastify-reply-from`](https://github.com/fastify/fastify-reply-from) built in options a fairly simple example would look like this:
+
+```js
+const Fastify = require('fastify')
+const proxy = require('fastify-http-proxy')
+const hyperid = require('hyperid')
+
+const server = Fastify()
+const uuid = hyperid()
+
+server.register(proxy, {
+  upstream: 'http://localhost:4001',
+  replyOptions: {
+    rewriteRequestHeaders: (originalReq, headers) => ({...headers, 'request-id': uuid()})
+  }
+})
+
+
+server.listen(3000);
+```
+
 ## Options
 
 This `fastify` plugin supports _all_ the options of
@@ -121,8 +144,6 @@ The results where gathered on the second run of `autocannon -c 100 -d 5
 URL`.
 
 ## TODO
-
-* [ ] Generate unique request ids and implement request tracking
 * [ ] Perform validations for incoming data
 
 ## License


### PR DESCRIPTION
Added an example with request tracking as discussed in #80 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
