### PR TITLE
Bump fastify-websocket from 1.1.2 to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "typescript": "^3.4.5"
   },
   "dependencies": {
-    "fastify-websocket": "^1.1.2",
+    "fastify-websocket": "^2.0.1",
     "ws": "^7.2.5",
     "fastify-reply-from": "^3.1.0"
   },


### PR DESCRIPTION
Caught this testing fastify `next` versions, this module currently installs fastify-plugin 1.x and 2.x.  Upgrading fastify-websocket here eliminates fastify-plugin 1.x.

#### Checklist

- [x] run `npm run test` ~and `npm run benchmark`~
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
