### PR TITLE
README: Corrected confusing example

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,15 +46,18 @@ const Fastify = require('fastify')
 const server = Fastify()
 const proxy = require('fastify-http-proxy')
 
+// /api/x will be proxied to http://my-api.example.com/x
 server.register(proxy, {
   upstream: 'http://my-api.example.com',
   prefix: '/api', // optional
   http2: false // optional
 })
 
+// /auth/user will be proxied to http://single-signon.example.com/signon/user
 server.register(proxy, {
-  upstream: 'http://single-signon.example.com/auth',
+  upstream: 'http://single-signon.example.com',
   prefix: '/auth', // optional
+  rewritePrefix: '/signon', // optional
   http2: false // optional
 })
 
@@ -62,6 +65,8 @@ server.listen(3000)
 ```
 
 Notice that in this case it is important to use the `prefix` option to tell the proxy how to properly route the requests across different upstreams.
+
+Also notice paths in `upstream` are ignored, so you need to use `rewritePrefix` to specify the target base path.
 
 For other examples, see `example.js`.
 


### PR DESCRIPTION
`upstream` is passed as `base` to `fastify-reply-from`. Quoting `fastify-reply-form` doc:

> *base*
> Set the base URL for all the forwarded requests. Will be required if http2 is set to true Note that path will be discarded.

So, specifying `/auth` in `upstream` has no effect at all, but this example seems to suggest `/auth/user` requests will be forwarded to `http://single-signon.example.com/auth/user`, when the real target will be `http://single-signon.example.com/user`.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
