### PR TITLE
Added regression test with undici with a body

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,13 +24,13 @@
   },
   "homepage": "https://github.com/fastify/fastify-http-proxy#readme",
   "devDependencies": {
-    "@types/node": "^14.0.18",
-    "@typescript-eslint/parser": "^3.6.0",
+    "@types/node": "^14.0.27",
+    "@typescript-eslint/parser": "^3.7.1",
     "eslint-plugin-typescript": "^0.14.0",
     "express": "^4.16.4",
-    "express-http-proxy": "^1.5.0",
+    "express-http-proxy": "^1.6.2",
     "fastify": "^3.0.0",
-    "got": "^11.4.0",
+    "got": "^11.5.1",
     "http-errors": "^1.8.0",
     "http-proxy": "^1.17.0",
     "make-promises-safe": "^5.0.0",
@@ -38,13 +38,13 @@
     "simple-get": "^4.0.0",
     "snazzy": "^8.0.0",
     "standard": "^14.0.2",
-    "tap": "^14.0.0",
+    "tap": "^14.10.8",
     "tsd": "^0.13.1",
-    "typescript": "^3.9.6"
+    "typescript": "^3.9.7"
   },
   "dependencies": {
-    "fastify-reply-from": "^3.1.2",
-    "fastify-websocket": "^2.0.3",
+    "fastify-reply-from": "^3.1.3",
+    "fastify-websocket": "^2.0.6",
     "ws": "^7.3.1"
   },
   "tsd": {

--- a/test/test.js
+++ b/test/test.js
@@ -347,6 +347,32 @@ async function run () {
 
     t.match(body, 'THIS IS ROOT')
   })
+
+  test('undici POST', async t => {
+    const proxyServer = Fastify()
+
+    proxyServer.register(proxy, {
+      upstream: `http://localhost:${origin.server.address().port}`,
+      undici: true
+    })
+
+    await proxyServer.listen(0)
+
+    t.tearDown(() => {
+      proxyServer.close()
+    })
+
+    const {
+      headers: { location }
+    } = await got(
+      `http://localhost:${proxyServer.server.address().port}/this-has-data`,
+      {
+        method: 'POST',
+        json: { hello: 'world' }
+      }
+    )
+    t.equal(location, '/something')
+  })
 }
 
 run()


### PR DESCRIPTION
Added a regression test to cover for https://github.com/mcollina/undici/pull/270

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
