### PR TITLE
Add fast proxy benchmark

### DIFF
--- a/benchmarks/fast-proxy.js
+++ b/benchmarks/fast-proxy.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const Fastify = require('fastify')
+const proxyCreator = require('fast-proxy')
+
+async function startProxy (base) {
+  const server = Fastify()
+  let undici = false
+
+  if (process.env.UNDICI) {
+    undici = {
+      connections: 100,
+      pipelining: 10
+    }
+  }
+
+  const { proxy } = proxyCreator({ base, undici, http2: !!process.env.HTTP2 })
+  server.get('/', (request, reply) => {
+    proxy(request.raw, reply.raw, request.url, {})
+  })
+
+  await server.listen(3000)
+  return server
+}
+
+startProxy('http://localhost:3001')

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "eslint-plugin-typescript": "^0.14.0",
     "express": "^4.16.4",
     "express-http-proxy": "^1.6.2",
+    "fast-proxy": "^1.7.0",
     "fastify": "^3.0.0",
     "got": "^11.5.1",
     "http-errors": "^1.8.0",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Hi. Thanks for the nice tool.

I recently use this in my work and I find out that there are some proxy plugins here. Seem's this one and fast-proxy are both under fastify org. So I'm interested in the benchmark result and add the benchmark here since this plugin looks more officially.

I haven't change the benchmark result in README since it depends on the running machine and you may update it. :)