### PR TITLE
Remove fastify-websocket, proxy ws events directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,8 @@ This module has _partial_ support for forwarding websockets by passing a
 A few things are missing:
 
 1. forwarding headers as well as `rewriteHeaders`
-2. support for paths, `prefix` and `rewritePrefix`
-3. request id logging
+2. request id logging
+3. support `ignoreTrailingSlash`
 
 Pull requests are welcome to finish this feature.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,11 @@ import {
   FastifyReplyFromOptions
 } from "fastify-reply-from"
 
+import {
+  ClientOptions,
+  ServerOptions
+} from "ws"
+
 export interface FastifyHttpProxyOptions extends FastifyReplyFromOptions {
   upstream: string;
   prefix?: string;
@@ -18,6 +23,9 @@ export interface FastifyHttpProxyOptions extends FastifyReplyFromOptions {
   beforeHandler?: preHandlerHookHandler;
   config?: Object;
   replyOptions?: Object;
+  websocket?: boolean
+  wsClientOptions?: ClientOptions
+  wsServerOptions?: ServerOptions
 }
 
 declare const fastifyHttpProxy: FastifyPlugin<FastifyHttpProxyOptions>;

--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ function setupWebSocketProxy (fastify, options) {
   })
 }
 
-module.exports = async function (fastify, opts) {
+async function httpProxy (fastify, opts) {
   if (!opts.upstream) {
     throw new Error('upstream must be specified')
   }
@@ -155,3 +155,10 @@ module.exports = async function (fastify, opts) {
     setupWebSocketProxy(fastify, opts)
   }
 }
+
+httpProxy[Symbol.for('plugin-meta')] = {
+  fastify: '^3.0.0',
+  name: 'fastify-http-proxy'
+}
+
+module.exports = httpProxy

--- a/index.js
+++ b/index.js
@@ -83,10 +83,7 @@ function setupWebSocketProxy (fastify, options) {
   server.on('connection', (source, request) => {
     const url = createWebSocketUrl(options, request)
 
-    const target = new WebSocket(url, {
-      rejectUnauthorized: process.env.NODE_ENV === 'production',
-      ...options.wsClientOptions
-    })
+    const target = new WebSocket(url, options.wsClientOptions)
 
     fastify.log.debug({ url: url.href }, 'proxy websocket')
     proxyWebSockets(source, target)

--- a/index.js
+++ b/index.js
@@ -73,6 +73,13 @@ function setupWebSocketProxy (fastify, options) {
     ...options.wsServerOptions
   })
 
+  fastify.addHook('onClose', (instance, done) => {
+    for (const client of server.clients) {
+      client.close()
+    }
+    done()
+  })
+
   server.on('connection', (source, request) => {
     const url = createWebSocketUrl(options, request)
 

--- a/index.js
+++ b/index.js
@@ -1,10 +1,90 @@
 'use strict'
 
 const From = require('fastify-reply-from')
-const WebSocketPlugin = require('fastify-websocket')
 const WebSocket = require('ws')
-const { pipeline } = require('stream')
-const nonWsMethods = ['DELETE', 'HEAD', 'PATCH', 'POST', 'PUT', 'OPTIONS']
+
+const httpMethods = ['DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT', 'OPTIONS']
+
+function liftErrorCode (code) {
+  if (typeof code !== 'number') {
+    // Sometimes "close" event emits with a non-numeric value
+    return 1011
+  } else if (code === 1004 || code === 1005 || code === 1006) {
+    // ws module forbid those error codes usage, lift to "application level" (4xxx)
+    return 4000 + (code % 1000)
+  } else {
+    return code
+  }
+}
+
+function closeWebSocket (socket, code, reason) {
+  if (socket.readyState === WebSocket.OPEN) {
+    socket.close(liftErrorCode(code), reason)
+  }
+}
+
+function waitConnection (socket, write) {
+  if (socket.readyState === WebSocket.CONNECTING) {
+    socket.once('open', write)
+  } else {
+    write()
+  }
+}
+
+function proxyWebSockets (source, target) {
+  function close (code, reason) {
+    closeWebSocket(source, code, reason)
+    closeWebSocket(target, code, reason)
+  }
+
+  source.on('message', data => waitConnection(target, () => target.send(data)))
+  source.on('ping', data => waitConnection(target, () => target.ping(data)))
+  source.on('pong', data => waitConnection(target, () => target.pong(data)))
+  source.on('close', close)
+  source.on('error', error => close(1011, error.message))
+  source.on('unexpected-response', () => close(1011, 'unexpected response'))
+
+  // source WebSocket is already connected because it is created by ws server
+  target.on('message', data => source.send(data))
+  target.on('ping', data => source.ping(data))
+  target.on('pong', data => source.pong(data))
+  target.on('close', close)
+  target.on('error', error => close(1011, error.message))
+  target.on('unexpected-response', () => close(1011, 'unexpected response'))
+}
+
+function createWebSocketUrl (options, request) {
+  const source = new URL(request.url, 'http://127.0.0.1')
+
+  const target = new URL(
+    options.rewritePrefix || options.prefix || source.pathname,
+    options.upstream
+  )
+
+  target.search = source.search
+
+  return target
+}
+
+function setupWebSocketProxy (fastify, options) {
+  const server = new WebSocket.Server({
+    path: options.prefix,
+    server: fastify.server,
+    ...options.wsServerOptions
+  })
+
+  server.on('connection', (source, request) => {
+    const url = createWebSocketUrl(options, request)
+
+    const target = new WebSocket(url, {
+      rejectUnauthorized: process.env.NODE_ENV === 'production',
+      ...options.wsClientOptions
+    })
+
+    fastify.log.debug({ url: url.href }, 'proxy websocket')
+    proxyWebSockets(source, target)
+  })
+}
 
 module.exports = async function (fastify, opts) {
   if (!opts.upstream) {
@@ -46,33 +126,16 @@ module.exports = async function (fastify, opts) {
     done(null, payload)
   }
 
-  if (opts.websocket) {
-    fastify.register(WebSocketPlugin, opts.websocket)
-  }
-
-  fastify.get('/', {
-    preHandler,
-    config: opts.config || {},
-    handler,
-    wsHandler
-  })
-  fastify.get('/*', {
-    preHandler,
-    config: opts.config || {},
-    handler,
-    wsHandler
-  })
-
   fastify.route({
     url: '/',
-    method: nonWsMethods,
+    method: httpMethods,
     preHandler,
     config: opts.config || {},
     handler
   })
   fastify.route({
     url: '/*',
-    method: nonWsMethods,
+    method: httpMethods,
     preHandler,
     config: opts.config || {},
     handler
@@ -84,21 +147,7 @@ module.exports = async function (fastify, opts) {
     reply.from(dest || '/', replyOpts)
   }
 
-  function wsHandler (conn, req) {
-    // TODO support paths and querystrings
-    // TODO support rewriteHeader
-    // TODO support rewritePrefix
-    const ws = new WebSocket(opts.upstream)
-    const stream = WebSocket.createWebSocketStream(ws)
-
-    // TODO fastify-websocket should create a logger for each connection
-    fastify.log.info('starting websocket tunnel')
-    pipeline(conn, stream, conn, function (err) {
-      if (err) {
-        fastify.log.info({ err }, 'websocket tunnel terminated with error')
-        return
-      }
-      fastify.log.info('websocket tunnel terminated')
-    })
+  if (opts.websocket) {
+    setupWebSocketProxy(fastify, opts)
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "http-errors": "^1.8.0",
     "http-proxy": "^1.17.0",
     "make-promises-safe": "^5.0.0",
-    "pre-commit": "^1.2.2",
     "simple-get": "^4.0.0",
     "snazzy": "^9.0.0",
     "standard": "^16.0.3",
@@ -46,8 +45,7 @@
   },
   "dependencies": {
     "fastify-reply-from": "^3.1.3",
-    "fastify-websocket": "^2.0.7",
-    "ws": "^7.3.1"
+    "ws": "^7.4.1"
   },
   "tsd": {
     "directory": "test"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "homepage": "https://github.com/fastify/fastify-http-proxy#readme",
   "devDependencies": {
     "@types/node": "^14.0.27",
+    "@types/ws": "^7.4.0",
     "@typescript-eslint/parser": "^4.0.0",
     "eslint-plugin-typescript": "^0.14.0",
     "express": "^4.16.4",
@@ -38,6 +39,8 @@
     "make-promises-safe": "^5.0.0",
     "simple-get": "^4.0.0",
     "snazzy": "^9.0.0",
+    "socket.io": "^3.0.4",
+    "socket.io-client": "^3.0.4",
     "standard": "^16.0.3",
     "tap": "^14.10.8",
     "tsd": "^0.14.0",

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -21,6 +21,7 @@ test('proxy socket.io', async t => {
   await promisify(srvUpstream.listen.bind(srvUpstream))(0)
 
   const srvProxy = Fastify()
+  t.tearDown(srvProxy.close.bind(srvProxy))
 
   srvProxy.register(proxy, {
     upstream: `http://127.0.0.1:${srvUpstream.address().port}`,

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -1,0 +1,47 @@
+'use strict'
+
+const { test } = require('tap')
+const Fastify = require('fastify')
+const proxy = require('../')
+const ioServer = require('socket.io')
+const ioClient = require('socket.io-client')
+const { createServer } = require('http')
+const { promisify } = require('util')
+const { once } = require('events')
+
+test('proxy socket.io', async t => {
+  t.plan(2)
+
+  const srvUpstream = createServer()
+  t.tearDown(srvUpstream.close.bind(srvUpstream))
+
+  const srvSocket = new ioServer.Server(srvUpstream)
+  t.tearDown(srvSocket.close.bind(srvSocket))
+
+  await promisify(srvUpstream.listen.bind(srvUpstream))(0)
+
+  const srvProxy = Fastify()
+  t.tearDown(srvProxy.close.bind(srvProxy))
+
+  srvProxy.register(proxy, {
+    upstream: `http://127.0.0.1:${srvUpstream.address().port}`,
+    websocket: true
+  })
+
+  await srvProxy.listen(0)
+
+  srvSocket.on('connection', socket => {
+    socket.on('hello', data => {
+      t.is(data, 'world')
+      socket.emit('hi', 'socket')
+    })
+  })
+
+  const cliSocket = ioClient(`http://127.0.0.1:${srvUpstream.address().port}`)
+  t.tearDown(cliSocket.close.bind(cliSocket))
+
+  cliSocket.emit('hello', 'world')
+
+  const out = await once(cliSocket, 'hi')
+  t.is(out[0], 'socket')
+})

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -37,7 +37,7 @@ test('proxy socket.io', async t => {
     })
   })
 
-  const cliSocket = ioClient(`http://127.0.0.1:${srvUpstream.address().port}`)
+  const cliSocket = ioClient(`http://127.0.0.1:${srvProxy.server.address().port}`)
   t.tearDown(cliSocket.close.bind(cliSocket))
 
   cliSocket.emit('hello', 'world')

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -21,7 +21,6 @@ test('proxy socket.io', async t => {
   await promisify(srvUpstream.listen.bind(srvUpstream))(0)
 
   const srvProxy = Fastify()
-  t.tearDown(srvProxy.close.bind(srvProxy))
 
   srvProxy.register(proxy, {
     upstream: `http://127.0.0.1:${srvUpstream.address().port}`,
@@ -44,4 +43,9 @@ test('proxy socket.io', async t => {
 
   const out = await once(cliSocket, 'hi')
   t.is(out[0], 'socket')
+
+  await Promise.all([
+    once(cliSocket, 'disconnect'),
+    srvProxy.close()
+  ])
 })

--- a/test/test.js
+++ b/test/test.js
@@ -180,9 +180,9 @@ async function run () {
         t.deepEqual(reply.context.config, {
           foo: 'bar',
           url: '/*',
-          // GET is not there because of the nonWsMethods.
           method: [
             'DELETE',
+            'GET',
             'HEAD',
             'PATCH',
             'POST',

--- a/test/websocket.js
+++ b/test/websocket.js
@@ -33,7 +33,6 @@ test('basic websocket proxy', async (t) => {
   })
 
   await server.listen(0)
-  t.tearDown(server.close.bind(server))
 
   const ws = new WebSocket(`http://localhost:${server.server.address().port}`)
 
@@ -46,4 +45,9 @@ test('basic websocket proxy', async (t) => {
   const [buf] = await once(stream, 'data')
 
   t.is(buf.toString(), 'hello')
+
+  await Promise.all([
+    once(ws, 'close'),
+    server.close()
+  ])
 })

--- a/test/websocket.js
+++ b/test/websocket.js
@@ -33,6 +33,7 @@ test('basic websocket proxy', async (t) => {
   })
 
   await server.listen(0)
+  t.tearDown(server.close.bind(server))
 
   const ws = new WebSocket(`http://localhost:${server.server.address().port}`)
 


### PR DESCRIPTION
## Notable changes:
- Remove `fastify-websocket`: proxy `ws` events directly.
- Proxy query string with WebSockets.
- Support `prefix` and `rewritePrefix` options with WebSockets.
- Support custom `ws` options for both client and server.
- Add `socket.io` tests.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
