### PR TITLE
Add support for schema on proxy routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ configuration passed to the route.
 
 Object with [reply options](https://github.com/fastify/fastify-reply-from#replyfromsource-opts) for `fastify-reply-from`.
 
+### schema
+
+This option is the same as [specified here](https://www.fastify.io/docs/latest/Routes/#routes-options). Note that certain validations may not work properly depending on the proxy settings used - e.g. `body` - since payloads may be directly streamed.
+
 ## websocket
 
 This module has _partial_ support for forwarding websockets by passing a

--- a/index.js
+++ b/index.js
@@ -105,6 +105,7 @@ async function httpProxy (fastify, opts) {
 
   const preHandler = opts.preHandler || opts.beforeHandler
   const rewritePrefix = opts.rewritePrefix || ''
+  const schema = opts.schema
 
   const fromOpts = Object.assign({}, opts)
   fromOpts.base = opts.upstream
@@ -143,6 +144,7 @@ async function httpProxy (fastify, opts) {
     method: httpMethods,
     preHandler,
     config: opts.config || {},
+    schema,
     handler
   })
   fastify.route({
@@ -150,6 +152,7 @@ async function httpProxy (fastify, opts) {
     method: httpMethods,
     preHandler,
     config: opts.config || {},
+    schema,
     handler
   })
 


### PR DESCRIPTION
This adds support for `schema` on the routes set up - this can be useful for at least validating query-params (as well as other options if the proxy setup allows for it).

Alternatively if it's forseen that other `fastify.route` options might be wanted in the future, we could change this implementation to just spread from one parent option - e.g.

```
  fastify.route({
    url: '/',
    method: httpMethods,
    preHandler,
    config: opts.config || {},
    handler,
    ...(opts.routeOptions || {})
  })
```

I've opted not to do that here, as I feel it's slightly less ergonomic/memorable than just using route-options directly.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
