### PR TITLE
Allow passthrough redirects

### DIFF
--- a/example.js
+++ b/example.js
@@ -5,8 +5,13 @@ const proxy = require('.')
 
 async function startOrigin () {
   const origin = Fastify()
+
   origin.get('/', async (request, reply) => {
     return 'this is root'
+  })
+
+  origin.get('/redirect', async (request, reply) => {
+    return reply.redirect(302, 'https://fastify.io')
   })
 
   origin.get('/a', async (request, reply) => {

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 'use strict'
-
 const From = require('fastify-reply-from')
 const WebSocket = require('ws')
 
 const httpMethods = ['DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT', 'OPTIONS']
+const urlPattern = /^https?:\/\//
 
 function liftErrorCode (code) {
   if (typeof code !== 'number') {
@@ -30,6 +30,10 @@ function waitConnection (socket, write) {
     write()
   }
 }
+
+function isExternalUrl (url = '') {
+  return urlPattern.test(url)
+};
 
 function proxyWebSockets (source, target) {
   function close (code, reason) {
@@ -125,7 +129,7 @@ async function httpProxy (fastify, opts) {
 
   function rewriteHeaders (headers) {
     const location = headers.location
-    if (location) {
+    if (location && !isExternalUrl(location)) {
       headers.location = location.replace(rewritePrefix, fastify.prefix)
     }
     if (oldRewriteHeaders) {


### PR DESCRIPTION
#### Description
Allow absolute URL redirects when applicable. Closes #124 .

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
