### PR TITLE
improve typings for replyOptions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,18 +1,13 @@
 /// <reference types="node" />
 
-import {
-  FastifyPlugin,
-  preHandlerHookHandler
-} from "fastify";
+import { FastifyPlugin, preHandlerHookHandler } from "fastify";
 
 import {
-  FastifyReplyFromOptions
-} from "fastify-reply-from"
+  FastifyReplyFromOptions,
+  FastifyReplyFromHooks,
+} from "fastify-reply-from";
 
-import {
-  ClientOptions,
-  ServerOptions
-} from "ws"
+import { ClientOptions, ServerOptions } from "ws";
 
 export interface FastifyHttpProxyOptions extends FastifyReplyFromOptions {
   upstream: string;
@@ -22,10 +17,10 @@ export interface FastifyHttpProxyOptions extends FastifyReplyFromOptions {
   preHandler?: preHandlerHookHandler;
   beforeHandler?: preHandlerHookHandler;
   config?: Object;
-  replyOptions?: Object;
-  websocket?: boolean
-  wsClientOptions?: ClientOptions
-  wsServerOptions?: ServerOptions
+  replyOptions?: FastifyReplyFromHooks;
+  websocket?: boolean;
+  wsClientOptions?: ClientOptions;
+  wsServerOptions?: ServerOptions;
 }
 
 declare const fastifyHttpProxy: FastifyPlugin<FastifyHttpProxyOptions>;

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -14,7 +14,7 @@ app.register(fastifyHttpProxy, {
   rewritePrefix: "/u",
   http2: false,
   config: { key: 1 },
-  replyOptions: { opt: "a" },
+  replyOptions: { contentType: "application/json" },
   preHandler: (request, reply) => {
     expectType<RawRequestDefaultExpression>(request.raw);
     expectType<RawReplyDefaultExpression>(reply.raw);


### PR DESCRIPTION
#### Description

Current typings for `replyOptions` are coarse. This pull request improves on the existing typings by giving `replyOptions` the type `FastifyReplyFromHooks` (https://github.com/fastify/fastify-reply-from/blob/master/index.d.ts#L32), which appears to be the right type considering how `replyOptions` is used in this package:
https://github.com/fastify/fastify-http-proxy/blob/master/index.js#L159

Closes https://github.com/fastify/fastify-http-proxy/issues/126

Note: this is a **breaking change**. Existing consumers of the package might be passing properties to `replyOptions` that are not in `FastifyReplyFromHooks`. They'll result in a type error once this PR is merged.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added (no changes)
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
