### PR TITLE
feat: drop node v10 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10, 12, 14, 16]
+        node-version: [12, 14, 16]
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-http-proxy",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "proxy http requests, for Fastify",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-http-proxy",
-  "version": "6.0.0",
+  "version": "5.0.0",
   "description": "proxy http requests, for Fastify",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
`undici` v4 dropping support of node v10, and `fastify-reply-from` v6 relies on that.
`fastify-http-proxy` also affected by this after #162.

I am experiencing something similar to #136 currently, so I hope to use  `undici` v4's `strictContentLength` option in the next major release 😄 

ref: 
* https://github.com/fastify/fastify-reply-from/pull/179
* https://github.com/nodejs/undici/releases/tag/v4.0.0

#### Checklist

- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
