### PR TITLE
feat: add default and named export

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict'
 const From = require('fastify-reply-from')
-const FastifyPlugin = require('fastify-plugin')
 const WebSocket = require('ws')
 
 const httpMethods = ['DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT', 'OPTIONS']
@@ -192,7 +191,11 @@ async function httpProxy (fastify, opts) {
   }
 }
 
-module.exports = FastifyPlugin(httpProxy, {
+httpProxy[Symbol.for('plugin-meta')] = {
   fastify: '^3.0.0',
   name: 'fastify-http-proxy'
-})
+}
+
+module.exports = httpProxy
+module.exports.default = httpProxy
+module.exports.fastifyHttpProxy = httpProxy

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict'
 const From = require('fastify-reply-from')
+const FastifyPlugin = require('fastify-plugin')
 const WebSocket = require('ws')
 
 const httpMethods = ['DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT', 'OPTIONS']
@@ -191,9 +192,7 @@ async function httpProxy (fastify, opts) {
   }
 }
 
-httpProxy[Symbol.for('plugin-meta')] = {
+module.exports = FastifyPlugin(httpProxy, {
   fastify: '^3.0.0',
   name: 'fastify-http-proxy'
-}
-
-module.exports = httpProxy
+})

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "typescript": "^4.0.2"
   },
   "dependencies": {
-    "fastify-plugin": "^3.0.0",
     "fastify-reply-from": "^6.0.0",
     "ws": "^7.4.1"
   },

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "typescript": "^4.0.2"
   },
   "dependencies": {
+    "fastify-plugin": "^3.0.0",
     "fastify-reply-from": "^6.0.0",
     "ws": "^7.4.1"
   },

--- a/test/export.js
+++ b/test/export.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const t = require('tap')
+
+const fastifyHttpProxy = require('..')
+const defaultExport = require('..').default
+const { fastifyHttpProxy: namedExport } = require('..')
+
+t.test('module export', function (t) {
+  t.plan(1)
+  t.equal(typeof fastifyHttpProxy, 'function')
+})
+
+t.test('default export', function (t) {
+  t.plan(1)
+  t.equal(typeof defaultExport, 'function')
+})
+
+t.test('named export', function (t) {
+  t.plan(1)
+  t.equal(typeof namedExport, 'function')
+})


### PR DESCRIPTION
Fixes: #169 
add `default` and `named` export.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
