### PR TITLE
force `ws://` protocol when instantiating a new `WebSocket`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 const From = require('fastify-reply-from')
 const WebSocket = require('ws')
-
+const { convertUrlToWebSocket } = require('./utils')
 const httpMethods = ['DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT', 'OPTIONS']
 const urlPattern = /^https?:\/\//
 
@@ -102,7 +102,7 @@ function setupWebSocketProxy(fastify, options, rewritePrefix) {
 
     const target = new URL(
       source.pathname.replace(fastify.prefix, rewritePrefix),
-      options.upstream.replace('http:', 'ws:')
+      convertUrlToWebSocket(options.upstream)
     )
 
     target.search = source.search

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const { convertUrlToWebSocket } = require('./utils')
 const httpMethods = ['DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT', 'OPTIONS']
 const urlPattern = /^https?:\/\//
 
-function liftErrorCode(code) {
+function liftErrorCode (code) {
   if (typeof code !== 'number') {
     // Sometimes "close" event emits with a non-numeric value
     return 1011
@@ -17,13 +17,13 @@ function liftErrorCode(code) {
   }
 }
 
-function closeWebSocket(socket, code, reason) {
+function closeWebSocket (socket, code, reason) {
   if (socket.readyState === WebSocket.OPEN) {
     socket.close(liftErrorCode(code), reason)
   }
 }
 
-function waitConnection(socket, write) {
+function waitConnection (socket, write) {
   if (socket.readyState === WebSocket.CONNECTING) {
     socket.once('open', write)
   } else {
@@ -31,12 +31,12 @@ function waitConnection(socket, write) {
   }
 }
 
-function isExternalUrl(url = '') {
+function isExternalUrl (url = '') {
   return urlPattern.test(url)
 };
 
-function proxyWebSockets(source, target) {
-  function close(code, reason) {
+function proxyWebSockets (source, target) {
+  function close (code, reason) {
     closeWebSocket(source, code, reason)
     closeWebSocket(target, code, reason)
   }
@@ -57,7 +57,7 @@ function proxyWebSockets(source, target) {
   target.on('unexpected-response', () => close(1011, 'unexpected response'))
 }
 
-function setupWebSocketProxy(fastify, options, rewritePrefix) {
+function setupWebSocketProxy (fastify, options, rewritePrefix) {
   const server = new WebSocket.Server({
     server: fastify.server,
     ...options.wsServerOptions
@@ -97,7 +97,7 @@ function setupWebSocketProxy(fastify, options, rewritePrefix) {
     proxyWebSockets(source, target)
   })
 
-  function createWebSocketUrl(request) {
+  function createWebSocketUrl (request) {
     const source = new URL(request.url, 'ws://127.0.0.1')
 
     const target = new URL(
@@ -111,7 +111,7 @@ function setupWebSocketProxy(fastify, options, rewritePrefix) {
   }
 }
 
-function generateRewritePrefix(prefix, opts) {
+function generateRewritePrefix (prefix, opts) {
   if (!prefix) {
     return ''
   }
@@ -125,7 +125,7 @@ function generateRewritePrefix(prefix, opts) {
   return rewritePrefix
 }
 
-async function httpProxy(fastify, opts) {
+async function httpProxy (fastify, opts) {
   if (!opts.upstream) {
     throw new Error('upstream must be specified')
   }
@@ -150,7 +150,7 @@ async function httpProxy(fastify, opts) {
     fastify.addContentTypeParser('*', bodyParser)
   }
 
-  function rewriteHeaders(headers) {
+  function rewriteHeaders (headers) {
     const location = headers.location
     if (location && !isExternalUrl(location)) {
       headers.location = location.replace(rewritePrefix, fastify.prefix)
@@ -161,7 +161,7 @@ async function httpProxy(fastify, opts) {
     return headers
   }
 
-  function bodyParser(req, payload, done) {
+  function bodyParser (req, payload, done) {
     done(null, payload)
   }
 
@@ -180,7 +180,7 @@ async function httpProxy(fastify, opts) {
     handler
   })
 
-  function handler(request, reply) {
+  function handler (request, reply) {
     let dest = request.raw.url
     dest = dest.replace(this.prefix, rewritePrefix)
     reply.from(dest || '/', replyOpts)

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 const From = require('fastify-reply-from')
 const WebSocket = require('ws')
 const { convertUrlToWebSocket } = require('./utils')
+
 const httpMethods = ['DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT', 'OPTIONS']
 const urlPattern = /^https?:\/\//
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@types/node": "^16.0.0",
     "@types/ws": "^7.4.0",
     "@typescript-eslint/parser": "^4.0.0",
-    "eslint": "^7.31.0",
     "eslint-plugin-typescript": "^0.14.0",
     "express": "^4.16.4",
     "express-http-proxy": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@types/node": "^16.0.0",
     "@types/ws": "^7.4.0",
     "@typescript-eslint/parser": "^4.0.0",
+    "eslint": "^7.31.0",
     "eslint-plugin-typescript": "^0.14.0",
     "express": "^4.16.4",
     "express-http-proxy": "^1.6.2",

--- a/test/utils.js
+++ b/test/utils.js
@@ -11,7 +11,7 @@ t.test('convertUrlToWebSocket', function (t) {
     { before: 'wss://localhost', after: 'wss://localhost' }
   ]
   t.plan(expected.length)
-  expected.forEach(({ before, after }) => {
+  for (const { before, after } of expected) {
     t.equal(convertUrlToWebSocket(before), after)
-  })
+  }
 })

--- a/test/utils.js
+++ b/test/utils.js
@@ -8,10 +8,10 @@ t.test('convertUrlToWebSocket', function (t) {
     { before: 'http://localhost', after: 'ws://localhost' },
     { before: 'https://localhost', after: 'wss://localhost' },
     { before: 'ws://localhost', after: 'ws://localhost' },
-    { before: 'wss://localhost', after: 'wss://localhost' },
+    { before: 'wss://localhost', after: 'wss://localhost' }
   ]
   t.plan(expected.length)
   expected.forEach(({ before, after }) => {
-    t.equal(convertUrlToWebSocket(before), after);
+    t.equal(convertUrlToWebSocket(before), after)
   })
 })

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const t = require('tap')
+const { convertUrlToWebSocket } = require('../utils')
+
+t.test('convertUrlToWebSocket', function (t) {
+  const expected = [
+    { before: 'http://localhost', after: 'ws://localhost' },
+    { before: 'https://localhost', after: 'wss://localhost' },
+    { before: 'ws://localhost', after: 'ws://localhost' },
+    { before: 'wss://localhost', after: 'wss://localhost' },
+  ]
+  t.plan(expected.length)
+  expected.forEach(({ before, after }) => {
+    t.equal(convertUrlToWebSocket(before), after);
+  })
+})

--- a/test/utils.js
+++ b/test/utils.js
@@ -4,14 +4,17 @@ const t = require('tap')
 const { convertUrlToWebSocket } = require('../utils')
 
 t.test('convertUrlToWebSocket', function (t) {
-  const expected = [
-    { before: 'http://localhost', after: 'ws://localhost' },
-    { before: 'https://localhost', after: 'wss://localhost' },
-    { before: 'ws://localhost', after: 'ws://localhost' },
-    { before: 'wss://localhost', after: 'wss://localhost' }
+  const testData = [
+    { input: 'http://localhost', expected: 'ws://localhost' },
+    { input: 'https://localhost', expected: 'wss://localhost' },
+    { input: 'ws://localhost', expected: 'ws://localhost' },
+    { input: 'wss://localhost', expected: 'wss://localhost' },
+    { input: 'wronghttp://localhost', expected: 'wronghttp://localhost' },
+    { input: 'NOT_AN_URL', expected: 'NOT_AN_URL' }
+
   ]
-  t.plan(expected.length)
-  for (const { before, after } of expected) {
-    t.equal(convertUrlToWebSocket(before), after)
+  t.plan(testData.length)
+  for (const { input, expected } of testData) {
+    t.equal(convertUrlToWebSocket(input), expected)
   }
 })

--- a/test/websocket.js
+++ b/test/websocket.js
@@ -28,14 +28,14 @@ test('basic websocket proxy', async (t) => {
 
   const server = Fastify()
   server.register(proxy, {
-    upstream: `http://localhost:${origin.address().port}`,
+    upstream: `ws://localhost:${origin.address().port}`,
     websocket: true
   })
 
   await server.listen(0)
   t.teardown(server.close.bind(server))
 
-  const ws = new WebSocket(`http://localhost:${server.server.address().port}`)
+  const ws = new WebSocket(`ws://localhost:${server.server.address().port}`)
 
   await once(ws, 'open')
 
@@ -58,7 +58,7 @@ test('captures errors on start', async (t) => {
   await app.listen(0)
 
   const app2 = Fastify()
-  app2.register(proxy, { upstream: 'http://localhost', websocket: true })
+  app2.register(proxy, { upstream: 'ws://localhost', websocket: true })
 
   const appPort = app.server.address().port
 

--- a/test/ws-prefix-rewrite-core.js
+++ b/test/ws-prefix-rewrite-core.js
@@ -11,7 +11,7 @@ const got = require('got')
 
 const level = 'warn'
 
-async function proxyServer(t, backendURL, backendPath, proxyOptions, wrapperOptions) {
+async function proxyServer (t, backendURL, backendPath, proxyOptions, wrapperOptions) {
   const frontend = Fastify({ logger: { level } })
   const registerProxy = async fastify => {
     fastify.register(proxy, {
@@ -32,11 +32,11 @@ async function proxyServer(t, backendURL, backendPath, proxyOptions, wrapperOpti
   return [frontend, await frontend.listen(0)]
 }
 
-async function processRequest(t, frontendURL, path, expected) {
+async function processRequest (t, frontendURL, path, expected) {
   const url = new URL(path, frontendURL)
   t.comment('ws connecting to ' + url.toString())
-  const wsUrl = url.href.replace('http://', 'ws://');
-  console.log(wsUrl);
+  const wsUrl = url.href.replace('http://', 'ws://')
+  console.log(wsUrl)
   const ws = new WebSocket(wsUrl)
   let wsResult, gotResult
 
@@ -67,7 +67,7 @@ async function processRequest(t, frontendURL, path, expected) {
   t.equal(gotResult, expected)
 }
 
-async function handleProxy(info, { backendPath, proxyOptions, wrapperOptions }, expected, ...paths) {
+async function handleProxy (info, { backendPath, proxyOptions, wrapperOptions }, expected, ...paths) {
   t.test(info, async function (t) {
     const backend = Fastify({ logger: { level } })
     await backend.register(fastifyWebSocket)

--- a/test/ws-prefix-rewrite-core.js
+++ b/test/ws-prefix-rewrite-core.js
@@ -8,6 +8,7 @@ const fastifyWebSocket = require('fastify-websocket')
 const proxy = require('..')
 const WebSocket = require('ws')
 const got = require('got')
+const { convertUrlToWebSocket } = require('../utils')
 
 const level = 'warn'
 
@@ -35,7 +36,7 @@ async function proxyServer (t, backendURL, backendPath, proxyOptions, wrapperOpt
 async function processRequest (t, frontendURL, path, expected) {
   const url = new URL(path, frontendURL)
   t.comment('ws connecting to ' + url.toString())
-  const wsUrl = url.href.replace('http://', 'ws://')
+  const wsUrl = convertUrlToWebSocket(url.href)
   const ws = new WebSocket(wsUrl)
   let wsResult, gotResult
 

--- a/test/ws-prefix-rewrite-core.js
+++ b/test/ws-prefix-rewrite-core.js
@@ -11,7 +11,7 @@ const got = require('got')
 
 const level = 'warn'
 
-async function proxyServer(t, backendURL, backendPath, proxyOptions, wrapperOptions) {
+async function proxyServer (t, backendURL, backendPath, proxyOptions, wrapperOptions) {
   const frontend = Fastify({ logger: { level } })
   const registerProxy = async fastify => {
     fastify.register(proxy, {
@@ -32,7 +32,7 @@ async function proxyServer(t, backendURL, backendPath, proxyOptions, wrapperOpti
   return [frontend, await frontend.listen(0)]
 }
 
-async function processRequest(t, frontendURL, path, expected) {
+async function processRequest (t, frontendURL, path, expected) {
   const url = new URL(path, frontendURL)
   t.comment('ws connecting to ' + url.toString())
   const wsUrl = url.href.replace('http://', 'ws://')
@@ -66,7 +66,7 @@ async function processRequest(t, frontendURL, path, expected) {
   t.equal(gotResult, expected)
 }
 
-async function handleProxy(info, { backendPath, proxyOptions, wrapperOptions }, expected, ...paths) {
+async function handleProxy (info, { backendPath, proxyOptions, wrapperOptions }, expected, ...paths) {
   t.test(info, async function (t) {
     const backend = Fastify({ logger: { level } })
     await backend.register(fastifyWebSocket)

--- a/test/ws-prefix-rewrite-core.js
+++ b/test/ws-prefix-rewrite-core.js
@@ -11,7 +11,7 @@ const got = require('got')
 
 const level = 'warn'
 
-async function proxyServer (t, backendURL, backendPath, proxyOptions, wrapperOptions) {
+async function proxyServer(t, backendURL, backendPath, proxyOptions, wrapperOptions) {
   const frontend = Fastify({ logger: { level } })
   const registerProxy = async fastify => {
     fastify.register(proxy, {
@@ -32,10 +32,12 @@ async function proxyServer (t, backendURL, backendPath, proxyOptions, wrapperOpt
   return [frontend, await frontend.listen(0)]
 }
 
-async function processRequest (t, frontendURL, path, expected) {
+async function processRequest(t, frontendURL, path, expected) {
   const url = new URL(path, frontendURL)
   t.comment('ws connecting to ' + url.toString())
-  const ws = new WebSocket(url)
+  const wsUrl = url.href.replace('http://', 'ws://');
+  console.log(wsUrl);
+  const ws = new WebSocket(wsUrl)
   let wsResult, gotResult
 
   try {
@@ -65,7 +67,7 @@ async function processRequest (t, frontendURL, path, expected) {
   t.equal(gotResult, expected)
 }
 
-async function handleProxy (info, { backendPath, proxyOptions, wrapperOptions }, expected, ...paths) {
+async function handleProxy(info, { backendPath, proxyOptions, wrapperOptions }, expected, ...paths) {
   t.test(info, async function (t) {
     const backend = Fastify({ logger: { level } })
     await backend.register(fastifyWebSocket)

--- a/test/ws-prefix-rewrite-core.js
+++ b/test/ws-prefix-rewrite-core.js
@@ -11,7 +11,7 @@ const got = require('got')
 
 const level = 'warn'
 
-async function proxyServer (t, backendURL, backendPath, proxyOptions, wrapperOptions) {
+async function proxyServer(t, backendURL, backendPath, proxyOptions, wrapperOptions) {
   const frontend = Fastify({ logger: { level } })
   const registerProxy = async fastify => {
     fastify.register(proxy, {
@@ -32,11 +32,10 @@ async function proxyServer (t, backendURL, backendPath, proxyOptions, wrapperOpt
   return [frontend, await frontend.listen(0)]
 }
 
-async function processRequest (t, frontendURL, path, expected) {
+async function processRequest(t, frontendURL, path, expected) {
   const url = new URL(path, frontendURL)
   t.comment('ws connecting to ' + url.toString())
   const wsUrl = url.href.replace('http://', 'ws://')
-  console.log(wsUrl)
   const ws = new WebSocket(wsUrl)
   let wsResult, gotResult
 
@@ -67,7 +66,7 @@ async function processRequest (t, frontendURL, path, expected) {
   t.equal(gotResult, expected)
 }
 
-async function handleProxy (info, { backendPath, proxyOptions, wrapperOptions }, expected, ...paths) {
+async function handleProxy(info, { backendPath, proxyOptions, wrapperOptions }, expected, ...paths) {
   t.test(info, async function (t) {
     const backend = Fastify({ logger: { level } })
     await backend.register(fastifyWebSocket)

--- a/test/ws-prefix-rewrite.js
+++ b/test/ws-prefix-rewrite.js
@@ -11,7 +11,7 @@ const got = require('got')
 
 const level = 'warn'
 
-async function proxyServer(t, backendURL, backendPath, proxyOptions, wrapperOptions) {
+async function proxyServer (t, backendURL, backendPath, proxyOptions, wrapperOptions) {
   const frontend = Fastify({ logger: { level } })
   const registerProxy = async fastify => {
     fastify.register(proxy, {
@@ -31,7 +31,7 @@ async function proxyServer(t, backendURL, backendPath, proxyOptions, wrapperOpti
   return [frontend, await frontend.listen(0)]
 }
 
-async function processRequest(t, frontendURL, path, expected) {
+async function processRequest (t, frontendURL, path, expected) {
   const url = new URL(path, frontendURL)
   t.comment('ws connecting to ' + url.toString())
   const wsUrl = url.href.replace('http:', 'ws:')
@@ -65,7 +65,7 @@ async function processRequest(t, frontendURL, path, expected) {
   t.equal(gotResult, expected)
 }
 
-async function handleProxy(info, { backendPath, proxyOptions, wrapperOptions }, expected, ...paths) {
+async function handleProxy (info, { backendPath, proxyOptions, wrapperOptions }, expected, ...paths) {
   t.test(info, async function (t) {
     const backend = Fastify({ logger: { level } })
     await backend.register(fastifyWebSocket)

--- a/test/ws-prefix-rewrite.js
+++ b/test/ws-prefix-rewrite.js
@@ -11,7 +11,7 @@ const got = require('got')
 
 const level = 'warn'
 
-async function proxyServer (t, backendURL, backendPath, proxyOptions, wrapperOptions) {
+async function proxyServer(t, backendURL, backendPath, proxyOptions, wrapperOptions) {
   const frontend = Fastify({ logger: { level } })
   const registerProxy = async fastify => {
     fastify.register(proxy, {
@@ -31,10 +31,11 @@ async function proxyServer (t, backendURL, backendPath, proxyOptions, wrapperOpt
   return [frontend, await frontend.listen(0)]
 }
 
-async function processRequest (t, frontendURL, path, expected) {
+async function processRequest(t, frontendURL, path, expected) {
   const url = new URL(path, frontendURL)
   t.comment('ws connecting to ' + url.toString())
-  const ws = new WebSocket(url)
+  const wsUrl = url.href.replace('http:', 'ws:')
+  const ws = new WebSocket(wsUrl)
   let wsResult, gotResult
 
   try {
@@ -64,7 +65,7 @@ async function processRequest (t, frontendURL, path, expected) {
   t.equal(gotResult, expected)
 }
 
-async function handleProxy (info, { backendPath, proxyOptions, wrapperOptions }, expected, ...paths) {
+async function handleProxy(info, { backendPath, proxyOptions, wrapperOptions }, expected, ...paths) {
   t.test(info, async function (t) {
     const backend = Fastify({ logger: { level } })
     await backend.register(fastifyWebSocket)

--- a/utils.js
+++ b/utils.js
@@ -1,6 +1,6 @@
 'use strict'
-function convertUrlToWebSocket(urlString) {
-  return urlString.replace(/(http)(s)?\:\/\//, "ws$2://");
+function convertUrlToWebSocket (urlString) {
+  return urlString.replace(/(http)(s)?:\/\//, 'ws$2://')
 }
 
 module.exports = {

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,8 @@
+'use strict'
+function convertUrlToWebSocket(urlString) {
+  return urlString.replace(/(http)(s)?\:\/\//, "ws$2://");
+}
+
+module.exports = {
+  convertUrlToWebSocket
+}

--- a/utils.js
+++ b/utils.js
@@ -1,7 +1,7 @@
 'use strict'
 
-function convertUrlToWebSocket(urlString) {
-  return urlString.replace(/(http)(s)?:\/\//, 'ws$2://')
+function convertUrlToWebSocket (urlString) {
+  return urlString.replace(/^(http)(s)?:\/\//, 'ws$2://')
 }
 
 module.exports = {

--- a/utils.js
+++ b/utils.js
@@ -1,5 +1,6 @@
 'use strict'
-function convertUrlToWebSocket (urlString) {
+
+function convertUrlToWebSocket(urlString) {
   return urlString.replace(/(http)(s)?:\/\//, 'ws$2://')
 }
 


### PR DESCRIPTION
`ws@8.0.0` introduces a breaking change that throws a `SyntaxError` when calling `new WebSocket()` with an URL with `http://` protocol. 
This PR fixes such issue, forcing when needed the `ws://` protocol instead.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
