### PR TITLE
added support for dynamical upstream configuration

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ function generateRewritePrefix (prefix, opts) {
     return ''
   }
 
-  let rewritePrefix = opts.rewritePrefix || new URL(opts.upstream).pathname
+  let rewritePrefix = opts.rewritePrefix || new URL(opts.upstream || 'http://empty').pathname
 
   if (!prefix.endsWith('/') && rewritePrefix.endsWith('/')) {
     rewritePrefix = rewritePrefix.slice(0, -1)
@@ -127,7 +127,7 @@ function generateRewritePrefix (prefix, opts) {
 }
 
 async function httpProxy (fastify, opts) {
-  if (!opts.upstream) {
+  if (!opts.upstream && !(opts.upstream === '' && typeof opts?.replyOptions?.getUpstream === 'function')) {
     throw new Error('upstream must be specified')
   }
 


### PR DESCRIPTION
added support for dynamical upstream configuration
replyOptions.getUpstream must be specified for this

These changes allow using [getUpstream](https://github.com/fastify/fastify-reply-from/tree/98c80098828e46d99b7c69c36c1fa522d2172932#getupstreamoriginalreq-base) feature of [fastify-reply-from](https://github.com/fastify/fastify-reply-from) library to change upstream dynamically