### PR TITLE
Fix for returned 500 when URL contains Query Search Param

### DIFF
--- a/index.js
+++ b/index.js
@@ -184,7 +184,8 @@ async function httpProxy (fastify, opts) {
   })
 
   function handler (request, reply) {
-    let [dest] = request.raw.url.split('?')
+    const queryParamIndex = request.raw.url.indexOf()
+    let dest = request.raw.url.slice(0, queryParamIndex !== -1 ? queryParamIndex : undefined)
     dest = dest.replace(this.prefix, rewritePrefix)
     reply.from(dest || '/', replyOpts)
   }

--- a/index.js
+++ b/index.js
@@ -184,7 +184,7 @@ async function httpProxy (fastify, opts) {
   })
 
   function handler (request, reply) {
-    const queryParamIndex = request.raw.url.indexOf()
+    const queryParamIndex = request.raw.url.indexOf('?')
     let dest = request.raw.url.slice(0, queryParamIndex !== -1 ? queryParamIndex : undefined)
     dest = dest.replace(this.prefix, rewritePrefix)
     reply.from(dest || '/', replyOpts)

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict'
 const From = require('fastify-reply-from')
-const UrlData = require('fastify-url-data')
 const WebSocket = require('ws')
 const { convertUrlToWebSocket } = require('./utils')
 
@@ -146,7 +145,6 @@ async function httpProxy (fastify, opts) {
   fromOpts.rewriteHeaders = rewriteHeaders
 
   fastify.register(From, fromOpts)
-  fastify.register(UrlData)
 
   if (opts.proxyPayloads !== false) {
     fastify.addContentTypeParser('application/json', bodyParser)
@@ -186,7 +184,7 @@ async function httpProxy (fastify, opts) {
   })
 
   function handler (request, reply) {
-    let dest = request.urlData().path
+    let [dest] = request.raw.url.split('?')
     dest = dest.replace(this.prefix, rewritePrefix)
     reply.from(dest || '/', replyOpts)
   }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict'
 const From = require('fastify-reply-from')
+const UrlData = require('fastify-url-data')
 const WebSocket = require('ws')
 const { convertUrlToWebSocket } = require('./utils')
 
@@ -145,6 +146,7 @@ async function httpProxy (fastify, opts) {
   fromOpts.rewriteHeaders = rewriteHeaders
 
   fastify.register(From, fromOpts)
+  fastify.register(UrlData)
 
   if (opts.proxyPayloads !== false) {
     fastify.addContentTypeParser('application/json', bodyParser)
@@ -184,7 +186,7 @@ async function httpProxy (fastify, opts) {
   })
 
   function handler (request, reply) {
-    let dest = request.raw.url
+    let dest = request.urlData().path
     dest = dest.replace(this.prefix, rewritePrefix)
     reply.from(dest || '/', replyOpts)
   }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   },
   "dependencies": {
     "fastify-reply-from": "^6.0.0",
-    "fastify-url-data": "^3.0.3",
     "ws": "^8.0.0"
   },
   "tsd": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "fastify-reply-from": "^6.0.0",
+    "fastify-url-data": "^3.0.3",
     "ws": "^8.0.0"
   },
   "tsd": {

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -26,7 +26,7 @@ app.register(fastifyHttpProxy, {
   },
   base: 'whatever',
   cacheURLs: 10,
-  undici: { dummy: true }, // undici has no TS declarations yet
+  undici: {},
   http: {
     agentOptions: {
       keepAliveMsecs: 10 * 60 * 1000


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
