### PR TITLE
fix (types): update typescript definitions, typescript tests and harmonize directory structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Notice that in this case it is important to use the `prefix` option to tell the 
 
 Also notice paths in `upstream` are ignored, so you need to use `rewritePrefix` to specify the target base path.
 
-For other examples, see [`example.js`](example.js).
+For other examples, see [`example.js`](examples/example.js).
 
 ## Request tracking
 

--- a/examples/example.js
+++ b/examples/example.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Fastify = require('fastify')
-const proxy = require('.')
+const proxy = require('..')
 
 async function startOrigin () {
   const origin = Fastify()

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,13 +1,13 @@
-/// <reference types="node" />
+/// <reference types='node' />
 
-import { FastifyPlugin, preHandlerHookHandler } from "fastify";
+import { FastifyPluginCallback, preHandlerHookHandler } from 'fastify';
 
 import {
   FastifyReplyFromOptions,
   FastifyReplyFromHooks,
-} from "fastify-reply-from";
+} from 'fastify-reply-from';
 
-import { ClientOptions, ServerOptions } from "ws";
+import { ClientOptions, ServerOptions } from 'ws';
 
 export interface FastifyHttpProxyOptions extends FastifyReplyFromOptions {
   upstream: string;
@@ -25,5 +25,5 @@ export interface FastifyHttpProxyOptions extends FastifyReplyFromOptions {
   constraints?: { [name: string]: any };
 }
 
-declare const fastifyHttpProxy: FastifyPlugin<FastifyHttpProxyOptions>;
+export const fastifyHttpProxy: FastifyPluginCallback<FastifyHttpProxyOptions>;
 export default fastifyHttpProxy;

--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "ws": "^8.4.2"
   },
   "tsd": {
-    "directory": "test"
+    "directory": "test/types"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,10 +3,12 @@
   "version": "6.2.1",
   "description": "proxy http requests, for Fastify",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
-    "lint:fix": "standard --fix",
-    "lint:typescript": "standard --fix --parser @typescript-eslint/parser --plugin typescript test/types/*.ts",
-    "test": "standard | snazzy && tap test/*.js && npm run typescript",
+    "lint": "standard | snazzy",
+    "lint:fix": "standard --fix | snazzy",
+    "lint:typescript": "npm run lint:fix - --parser @typescript-eslint/parser --plugin typescript \"test/types/*.ts\"",
+    "test": "npm run lint && tap \"test/*.js\" && npm run typescript",
     "typescript": "tsd"
   },
   "repository": {
@@ -26,31 +28,31 @@
   "homepage": "https://github.com/fastify/fastify-http-proxy#readme",
   "devDependencies": {
     "@fastify/pre-commit": "^2.0.2",
-    "@types/node": "^16.0.0",
-    "@types/ws": "^8.2.0",
-    "@typescript-eslint/parser": "^4.0.0",
-    "eslint-plugin-typescript": "^0.14.0",
-    "express": "^4.16.4",
-    "express-http-proxy": "^1.6.2",
-    "fast-proxy": "^2.0.0",
-    "fastify": "^3.12.0",
+    "@types/node": "^16.11.19",
+    "@types/ws": "^8.2.2",
+    "@typescript-eslint/eslint-plugin": "^5.9.1",
+    "@typescript-eslint/parser": "^5.9.1",
+    "express": "^4.17.2",
+    "express-http-proxy": "^1.6.3",
+    "fast-proxy": "^2.1.0",
+    "fastify": "^3.25.3",
     "fastify-websocket": "^4.0.0",
-    "got": "^11.5.1",
-    "http-errors": "^1.8.0",
-    "http-proxy": "^1.17.0",
-    "make-promises-safe": "^5.0.0",
+    "got": "^11.8.3",
+    "http-errors": "^2.0.0",
+    "http-proxy": "^1.18.1",
+    "make-promises-safe": "^5.1.0",
     "simple-get": "^4.0.0",
     "snazzy": "^9.0.0",
-    "socket.io": "^4.0.0",
-    "socket.io-client": "^4.0.0",
-    "standard": "^16.0.3",
-    "tap": "^15.0.1",
-    "tsd": "^0.17.0",
-    "typescript": "^4.0.2"
+    "socket.io": "^4.4.1",
+    "socket.io-client": "^4.4.1",
+    "standard": "^16.0.4",
+    "tap": "^15.1.6",
+    "tsd": "^0.19.1",
+    "typescript": "^4.5.4"
   },
   "dependencies": {
-    "fastify-reply-from": "^6.0.0",
-    "ws": "^8.0.0"
+    "fastify-reply-from": "^6.4.1",
+    "ws": "^8.4.2"
   },
   "tsd": {
     "directory": "test"

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -1,21 +1,21 @@
-import fastify, { RawReplyDefaultExpression, RawRequestDefaultExpression } from "fastify";
-import fastifyHttpProxy from "..";
-import { expectType } from "tsd";
+import fastify, { RawReplyDefaultExpression, RawRequestDefaultExpression } from 'fastify';
+import { expectType } from 'tsd';
+import fastifyHttpProxy from '..';
 
 const app = fastify();
 
 app.register(fastifyHttpProxy, {
-  upstream: "http://origin.asd"
+  upstream: 'http://origin.asd'
 });
 
 app.register(fastifyHttpProxy, {
-  upstream: "http://origin.asd",
-  prefix: "/auth",
-  rewritePrefix: "/u",
+  upstream: 'http://origin.asd',
+  prefix: '/auth',
+  rewritePrefix: '/u',
   http2: false,
   config: { key: 1 },
-  replyOptions: { contentType: "application/json" },
-  httpMethods: ["DELETE", "GET", "HEAD", "PATCH", "POST", "PUT", "OPTIONS"],
+  replyOptions: { contentType: 'application/json' },
+  httpMethods: ['DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT', 'OPTIONS'],
   preHandler: (request, reply) => {
     expectType<RawRequestDefaultExpression>(request.raw);
     expectType<RawReplyDefaultExpression>(reply.raw);
@@ -26,7 +26,14 @@ app.register(fastifyHttpProxy, {
   },
   base: 'whatever',
   cacheURLs: 10,
-  undici: { dummy: true }, // undici has no TS declarations yet
+  undici: {
+    connections: 128,
+    pipelining: 1,
+    keepAliveTimeout: 60 * 1000,
+    tls: {
+      rejectUnauthorized: false
+    }
+  },
   http: {
     agentOptions: {
       keepAliveMsecs: 10 * 60 * 1000

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -1,6 +1,6 @@
 import fastify, { RawReplyDefaultExpression, RawRequestDefaultExpression } from 'fastify';
 import { expectError, expectType } from 'tsd';
-import fastifyHttpProxy from '..';
+import fastifyHttpProxy from '../..';
 
 const app = fastify();
 

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -1,5 +1,5 @@
 import fastify, { RawReplyDefaultExpression, RawRequestDefaultExpression } from 'fastify';
-import { expectType } from 'tsd';
+import { expectError, expectType } from 'tsd';
 import fastifyHttpProxy from '..';
 
 const app = fastify();
@@ -49,3 +49,9 @@ app.register(fastifyHttpProxy, {
   sessionTimeout: 30000,
   constraints: { version: '1.0.2' }
 });
+
+expectError(
+  app.register(fastifyHttpProxy, {
+    thisOptionDoesNotExist: 'triggers a typescript error'
+  })
+);


### PR DESCRIPTION
Hello.

This PR aims to :
- fix a failing typescript definition test
- update typescript definitions and tests
- upgrade package dependencies
- harmonize directory structure

Superseed https://github.com/fastify/fastify-http-proxy/pull/225, https://github.com/fastify/fastify-http-proxy/pull/221, https://github.com/fastify/fastify-http-proxy/pull/215

#### Checklist

- [x] run `npm run test` ~~and `npm run benchmark`~~
- [x] tests ~~and/or benchmarks~~ are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
