### PR TITLE
feat: forward cookies to websocket proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ This module has _partial_ support for forwarding websockets by passing a
 [`@fastify/websocket`](https://github.com/fastify/fastify-websocket).
 A few things are missing:
 
-1. forwarding headers as well as `rewriteHeaders`
+1. forwarding headers as well as `rewriteHeaders`. Note: Only cookie headers are being forwarded
 2. request id logging
 3. support `ignoreTrailingSlash`
 

--- a/index.js
+++ b/index.js
@@ -90,9 +90,17 @@ function setupWebSocketProxy (fastify, options, rewritePrefix) {
       return
     }
 
+    let optionsWs = {}
+    if (request.headers.cookie) {
+      const headers = { cookie: request.headers.cookie }
+      optionsWs = { ...options.wsClientOptions, headers }
+    } else {
+      optionsWs = options.wsClientOptions
+    }
+
     const url = createWebSocketUrl(request)
 
-    const target = new WebSocket(url, options.wsClientOptions)
+    const target = new WebSocket(url, optionsWs)
 
     fastify.log.debug({ url: url.href }, 'proxy websocket')
     proxyWebSockets(source, target)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
## Notes:
I was planning to forward all the headers, but then I got the `Invalid Sec-WebSocket-Accept header` error, so I decided starting only forwarding the cookies.

I tested this with https://github.com/pearofducks/rollup-plugin-dev, and the cookie forwarding seems to be working as expected!

Let me know if you know how to fix the `Invalid Sec-WebSocket-Accept header`, and I can update this PR or create a new one. Maybe we should forward all the header with exception of the "sec-websocket-*" headers??.

Thanks in advance

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
