### PR TITLE
Allow rewritePrefix without having to need prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ server.register(proxy, {
   http2: false // optional
 })
 
+// /user will be proxied to http://single-signon.example.com/signon/user
+server.register(proxy, {
+  upstream: 'http://single-signon.example.com',
+  rewritePrefix: '/signon', // optional
+  http2: false // optional
+})
+
 server.listen(3000)
 ```
 

--- a/index.js
+++ b/index.js
@@ -120,11 +120,7 @@ function setupWebSocketProxy (fastify, options, rewritePrefix) {
   }
 }
 
-function generateRewritePrefix (prefix, opts) {
-  if (!prefix) {
-    return ''
-  }
-
+function generateRewritePrefix (prefix = '', opts) {
   let rewritePrefix = opts.rewritePrefix || (opts.upstream ? new URL(opts.upstream).pathname : '/')
 
   if (!prefix.endsWith('/') && rewritePrefix.endsWith('/')) {

--- a/test/test.js
+++ b/test/test.js
@@ -424,6 +424,26 @@ async function run () {
     t.equal(firstProxyPrefix.body, 'this is /api2/a')
   })
 
+  test('rewritePrefix without prefix', async t => {
+    const proxyServer = Fastify()
+
+    proxyServer.register(proxy, {
+      upstream: `http://localhost:${origin.server.address().port}`,
+      rewritePrefix: '/api2'
+    })
+
+    await proxyServer.listen({ port: 0 })
+
+    t.teardown(() => {
+      proxyServer.close()
+    })
+
+    const firstProxyPrefix = await got(
+      `http://localhost:${proxyServer.server.address().port}/a`
+    )
+    t.equal(firstProxyPrefix.body, 'this is /api2/a')
+  })
+
   test('rewrite location headers', async t => {
     const proxyServer = Fastify()
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

rewritePrefix is currently ignored if prefix isn't filled in. This isn't documented and caused me struggles without reading the source code.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
