### PR TITLE
Pass WebSocket subprotocol to upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ A few things are missing:
 1. forwarding headers as well as `rewriteHeaders`. Note: Only cookie headers are being forwarded
 2. request id logging
 3. support `ignoreTrailingSlash`
+4. forwarding more than one subprotocols. Note: Only the first subprotocol is being forwarded
 
 Pull requests are welcome to finish this feature.
 

--- a/index.js
+++ b/index.js
@@ -90,6 +90,11 @@ function setupWebSocketProxy (fastify, options, rewritePrefix) {
       return
     }
 
+    const subprotocols = []
+    if (source.protocol) {
+      subprotocols.push(source.protocol)
+    }
+
     let optionsWs = {}
     if (request.headers.cookie) {
       const headers = { cookie: request.headers.cookie }
@@ -100,7 +105,7 @@ function setupWebSocketProxy (fastify, options, rewritePrefix) {
 
     const url = createWebSocketUrl(request)
 
-    const target = new WebSocket(url, optionsWs)
+    const target = new WebSocket(url, subprotocols, optionsWs)
 
     fastify.log.debug({ url: url.href }, 'proxy websocket')
     proxyWebSockets(source, target)


### PR DESCRIPTION
This PR updates WebSocket proxy feature to pass the subprotocol, as indicated by the client in `Sec-WebSocket-Protocol` header, to the upstream WebSocket server.
This change is necessary for proxying GraphQL WebSocket connections, in which the server often checks the subprotocol header.

A limitation of this implementation is that, if the incoming `Sec-WebSocket-Protocol` header contains multiple subprotocols, the proxy always picks the first subprotocol, and does not give upstream server an opportunity to make this choice.
This limitation is caused by `WebSocketServer` option `handleProtocols` being a synchronous function, in which it's impossible to pass the list of subprotocols and allow the upstream to make a choice.

#### Checklist

- [X] run `npm run test`
- [ ] run `npm run benchmark` - it's unavailable in this repository
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
