### PR TITLE
Preserve text vs binary frames

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function proxyWebSockets (source, target) {
     closeWebSocket(target, code, reason)
   }
 
-  source.on('message', data => waitConnection(target, () => target.send(data)))
+  source.on('message', (data, binary) => waitConnection(target, () => target.send(data, { binary })))
   source.on('ping', data => waitConnection(target, () => target.ping(data)))
   source.on('pong', data => waitConnection(target, () => target.pong(data)))
   source.on('close', close)
@@ -50,7 +50,7 @@ function proxyWebSockets (source, target) {
   source.on('unexpected-response', () => close(1011, 'unexpected response'))
 
   // source WebSocket is already connected because it is created by ws server
-  target.on('message', data => source.send(data))
+  target.on('message', (data, binary) => source.send(data, { binary }))
   target.on('ping', data => source.ping(data))
   target.on('pong', data => source.pong(data))
   target.on('close', close)


### PR DESCRIPTION
fixes #255

One more change needed for GraphQL proxy to work.
I have tested this with `graphql-request` client.

#### Checklist

- [X] run `npm run test`
- [ ] `npm run benchmark` - it's unavailable in this repository
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added - this is a bug fix for a bug that is not listed in documentation
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
