### PR TITLE
Allow attaching multiple WebSocket proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ An array that contains the types of the methods. Default: `['DELETE', 'GET', 'HE
 This module has _partial_ support for forwarding websockets by passing a
 `websocket` option. All those options are going to be forwarded to
 [`@fastify/websocket`](https://github.com/fastify/fastify-websocket).
+
+Multiple websocket proxies may be attached to the same HTTP server at different paths.
+In this case, only the first `wsServerOptions` is applied.
+
 A few things are missing:
 
 1. forwarding headers as well as `rewriteHeaders`. Note: Only cookie headers are being forwarded

--- a/test/websocket.js
+++ b/test/websocket.js
@@ -57,6 +57,52 @@ test('basic websocket proxy', async (t) => {
   ])
 })
 
+test('multiple websocket upstreams', async (t) => {
+  t.plan(8)
+
+  const server = Fastify()
+
+  for (const name of ['/A', '/A/B', '/C/D', '/C']) {
+    const origin = createServer()
+    const wss = new WebSocket.Server({ server: origin })
+    t.teardown(wss.close.bind(wss))
+    t.teardown(origin.close.bind(origin))
+
+    wss.once('connection', (ws) => {
+      ws.once('message', message => {
+        t.equal(message.toString(), `hello ${name}`)
+        // echo
+        ws.send(message)
+      })
+    })
+
+    await promisify(origin.listen.bind(origin))({ port: 0 })
+    server.register(proxy, {
+      prefix: name,
+      upstream: `ws://localhost:${origin.address().port}`,
+      websocket: true
+    })
+  }
+
+  await server.listen({ port: 0 })
+  t.teardown(server.close.bind(server))
+
+  const wsClients = []
+  for (const name of ['/A', '/A/B', '/C/D', '/C']) {
+    const ws = new WebSocket(`ws://localhost:${server.server.address().port}${name}`)
+    await once(ws, 'open')
+    ws.send(`hello ${name}`)
+    const [reply] = await once(ws, 'message')
+    t.equal(reply.toString(), `hello ${name}`)
+    wsClients.push(ws)
+  }
+
+  await Promise.all([
+    ...wsClients.map(ws => once(ws, 'close')),
+    server.close()
+  ])
+})
+
 test('captures errors on start', async (t) => {
   const app = Fastify()
   await app.listen({ port: 0 })


### PR DESCRIPTION
Previously, if multiple WebSockets-enabled proxies are added to the same `fastify.Server` instance at distinct URI prefixes, the program crashes with error:

```text
/app/node_modules/.pnpm/ws@8.8.0/node_modules/ws/lib/websocket-server.js:363
      throw new Error(
      ^

Error: server.handleUpgrade() was called more than once with the same socket, possibly due to a misconfiguration
    at WebSocketServer.completeUpgrade (/app/node_modules/.pnpm/ws@8.8.0/node_modules/ws/lib/websocket-server.js:363:13)
    at WebSocketServer.handleUpgrade (/app/node_modules/.pnpm/ws@8.8.0/node_modules/ws/lib/websocket-server.js:339:10)
    at Server.upgrade (/app/node_modules/.pnpm/ws@8.8.0/node_modules/ws/lib/websocket-server.js:114:16)
    at Server.emit (node:events:539:35)
    at onParserExecuteCommon (node:_http_server:732:14)
    at onParserExecute (node:_http_server:646:3)
 ELIFECYCLE  Command failed with exit code 1.
```

This PR fixes this problem by only attaching one `WebSocket.Server` to the same HTTP server, and then internally dispatches WebSocket connections to different upstreams via longest prefix match lookup among registered prefixes.

#### Checklist

- [X] run `npm run test`
- [ ] `npm run benchmark` - it's unavailable in this repository
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
