### PR TITLE
feat: add request argument to rewriteHeaders

### DIFF
--- a/index.js
+++ b/index.js
@@ -200,13 +200,13 @@ async function httpProxy (fastify, opts) {
     fastify.addContentTypeParser('*', bodyParser)
   }
 
-  function rewriteHeaders (headers) {
+  function rewriteHeaders (headers, req) {
     const location = headers.location
     if (location && !isExternalUrl(location)) {
       headers.location = location.replace(rewritePrefix, fastify.prefix)
     }
     if (oldRewriteHeaders) {
-      headers = oldRewriteHeaders(headers)
+      headers = oldRewriteHeaders(headers, req)
     }
     return headers
   }

--- a/test/test.js
+++ b/test/test.js
@@ -387,7 +387,10 @@ async function run () {
       upstream: `http://localhost:${origin.server.address().port}`,
       prefix: '/api',
       replyOptions: {
-        rewriteHeaders: headers => Object.assign({ 'x-test': 'test' }, headers)
+        rewriteHeaders: (headers, req) => Object.assign({
+          'x-test': 'test',
+          'x-req': req.headers['x-req']
+        }, headers)
       }
     })
 
@@ -397,10 +400,13 @@ async function run () {
       proxyServer.close()
     })
 
-    const { headers } = await got(
-      `http://localhost:${proxyServer.server.address().port}/api`
-    )
-    t.match(headers, { 'x-test': 'test' })
+    const { headers } = await got({
+      url: `http://localhost:${proxyServer.server.address().port}/api`,
+      headers: {
+        'x-req': 'from-header'
+      }
+    })
+    t.match(headers, { 'x-test': 'test', 'x-req': 'from-header' })
   })
 
   test('rewritePrefix', async t => {


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

The `rewriteHeaders` callback of `fastify-reply-from` can receive a request as an argument. But the `rewriteHeaders` callback overwritten by `fastify-http-proxy` doesn't forward the request. Fixed this issue.