### PR TITLE
docs(readme): fix route config link

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ fastify.addContentTypeParser('application/xml', (req, done) => {
 ### config
 
 An object accessible within the `preHandler` via `reply.context.config`.
-See [Config](https://www.fastify.io/docs/v2.1.x/Routes/#config) in the Fastify
+See [Config](https://www.fastify.io/docs/v4.8.x/Reference/Routes/#config) in the Fastify
 documentation for information on this option. Note: this is merged with other
 configuration passed to the route.
 


### PR DESCRIPTION
The route config link still points to document for fastify 2.1.x.

This MR modifies the link to 4.8.x (since there is no link for major version `4.x`).

It's slightly better than just pointing to `latest` as this plugin might not be compatible with the future fastify version (e.g. v5) right away.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
