### PR TITLE
Added support for parametric rewrite prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ server.register(proxy, {
   http2: false // optional
 })
 
+// /rest-api/123/endpoint will be proxied to http://my-rest-api.example.com/123/endpoint
+server.register(proxy, {
+  upstream: 'http://my-rest-api.example.com',
+  prefix: '/rest-api/:id/endpoint', // optional
+  rewritePrefix: '/:id/endpoint', // optional
+  http2: false // optional
+})
+
 // /auth/user will be proxied to http://single-signon.example.com/signon/user
 server.register(proxy, {
   upstream: 'http://single-signon.example.com',
@@ -117,6 +125,8 @@ An URL (including protocol) that represents the target server to use for proxyin
 ### prefix
 
 The prefix to mount this plugin on. All the requests to the current server starting with the given prefix will be proxied to the provided upstream.
+
+Parametric path is supported. To register a parametric path, use the colon before the parameter name.
 
 The prefix will be removed from the URL when forwarding the HTTP
 request.

--- a/index.js
+++ b/index.js
@@ -250,7 +250,13 @@ async function fastifyHttpProxy (fastify, opts) {
     if (this.prefix.includes(':')) {
       const requestedPathElements = request.url.split('/')
       const prefixPathWithVariables = this.prefix.split('/').map((_, index) => requestedPathElements[index]).join('/')
-      dest = dest.replace(prefixPathWithVariables, rewritePrefix)
+
+      let rewritePrefixWithVariables = rewritePrefix
+      for (const [name, value] of Object.entries(request.params)) {
+        rewritePrefixWithVariables = rewritePrefixWithVariables.replace(`:${name}`, value)
+      }
+
+      dest = dest.replace(prefixPathWithVariables, rewritePrefixWithVariables)
     } else {
       dest = dest.replace(this.prefix, rewritePrefix)
     }


### PR DESCRIPTION
This PR adds support for parametric path with both `prefix` and `rewritePrefix`
Example:
```javascript
// /rest-api/123/endpoint will be proxied to http://my-rest-api.example.com/123/endpoint
server.register(proxy, {
  upstream: 'http://my-rest-api.example.com',
  prefix: '/rest-api/:id/endpoint', // optional
  rewritePrefix: '/:id/endpoint', // optional
  http2: false // optional
})
```

#### Checklist

- [x] run `npm run test`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)