### PR TITLE
feat: The target websocket watch the specific url instead of upstream…

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,14 @@ A few things are missing:
 
 Pull requests are welcome to finish this feature.
 
+### `wsUpstream`
+Working only if property `websocket` is `true`.
+
+An URL (including protocol) that represents the target websockets to use for proxying websockets.
+Accepted both `https://` and `wss://`.
+
+Note that if property `wsUpstream` not specified then proxy will try to connect with the `upstream` property.
+
 ### `wsServerOptions`
 
 The options passed to [`new ws.Server()`](https://github.com/websockets/ws/blob/HEAD/doc/ws.md#class-websocketserver).

--- a/test/websocket.js
+++ b/test/websocket.js
@@ -407,3 +407,68 @@ test('Should gracefully close when clients attempt to connect after calling clos
   await server.close()
   await p
 })
+
+test('Proxy websocket with custom upstream url', async (t) => {
+  t.plan(5)
+
+  const origin = createServer()
+  const wss = new WebSocket.Server({ server: origin })
+
+  t.teardown(wss.close.bind(wss))
+  t.teardown(origin.close.bind(origin))
+
+  const serverMessages = []
+  wss.on('connection', (ws, request) => {
+    ws.on('message', (message, binary) => {
+      // Also need save request.url for check from what url the message is coming.
+      serverMessages.push([message.toString(), binary, request.url])
+      ws.send(message, { binary })
+    })
+  })
+
+  await promisify(origin.listen.bind(origin))({ port: 0 })
+  // Path for wsUpstream and for later check.
+  const path = '/some/path'
+  const server = Fastify()
+  server.register(proxy, {
+    upstream: `ws://localhost:${origin.address().port}`,
+    // Start proxy with different upstream, added path.
+    wsUpstream: `ws://localhost:${origin.address().port}${path}`,
+    websocket: true
+  })
+
+  await server.listen({ port: 0 })
+  t.teardown(server.close.bind(server))
+
+  // Start websocket with different upstream for connect, added path.
+  const ws = new WebSocket(`ws://localhost:${server.server.address().port}${path}`)
+  await once(ws, 'open')
+
+  const data = [{ message: 'hello', binary: false }, { message: 'fastify', binary: true, isBuffer: true }]
+  const dataLength = data.length
+  let dataIndex = 0
+
+  for (; dataIndex < dataLength; dataIndex++) {
+    const { message: msg, binary, isBuffer } = data[dataIndex]
+    const message = isBuffer
+      ? Buffer.from(msg)
+      : msg
+
+    ws.send(message, { binary })
+
+    const [reply, binaryAnswer] = await once(ws, 'message')
+
+    t.equal(reply.toString(), msg)
+    t.equal(binaryAnswer, binary)
+  }
+  // Also check "path", must be the same.
+  t.strictSame(serverMessages, [
+    ['hello', false, path],
+    ['fastify', true, path]
+  ])
+
+  await Promise.all([
+    once(ws, 'close'),
+    server.close()
+  ])
+})

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -22,6 +22,7 @@ declare namespace fastifyHttpProxy {
     config?: Object;
     replyOptions?: FastifyReplyFromHooks;
     websocket?: boolean;
+    wsUpstream?: string;
     wsClientOptions?: ClientOptions;
     wsServerOptions?: ServerOptions;
     httpMethods?: string[];


### PR DESCRIPTION
The target websocket watch the specific url instead of upstream(host) with path. [Issue](https://github.com/fastify/fastify-http-proxy/issues/303)

#### Checklist

- [ x ] run `npm run test`
- [ x ] tests are included
- [ x ] documentation is changed or added
- [ x ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
