### PR TITLE
fix: @fastify/reply-from params passing

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ const server = Fastify()
 server.register(require('@fastify/http-proxy'), {
   upstream: 'http://my-api.example.com',
   prefix: '/api', // optional
-  http2: false // optional
+  replyOptions: {
+    http2: false // optional
+  }
 })
 
 server.listen({ port: 3000 })
@@ -52,7 +54,9 @@ const proxy = require('@fastify/http-proxy')
 server.register(proxy, {
   upstream: 'http://my-api.example.com',
   prefix: '/api', // optional
-  http2: false // optional
+  replyOptions: {
+    http2: false // optional
+  }
 })
 
 // /rest-api/123/endpoint will be proxied to http://my-rest-api.example.com/123/endpoint
@@ -60,7 +64,9 @@ server.register(proxy, {
   upstream: 'http://my-rest-api.example.com',
   prefix: '/rest-api/:id/endpoint', // optional
   rewritePrefix: '/:id/endpoint', // optional
-  http2: false // optional
+  replyOptions: {
+    http2: false // optional
+  }
 })
 
 // /auth/user will be proxied to http://single-signon.example.com/signon/user
@@ -68,14 +74,18 @@ server.register(proxy, {
   upstream: 'http://single-signon.example.com',
   prefix: '/auth', // optional
   rewritePrefix: '/signon', // optional
-  http2: false // optional
+  replyOptions: {
+    http2: false // optional
+  }
 })
 
 // /user will be proxied to http://single-signon.example.com/signon/user
 server.register(proxy, {
   upstream: 'http://single-signon.example.com',
   rewritePrefix: '/signon', // optional
-  http2: false // optional
+  replyOptions: {
+    http2: false // optional
+  }
 })
 
 server.listen({ port: 3000 })

--- a/index.js
+++ b/index.js
@@ -230,18 +230,14 @@ async function fastifyHttpProxy (fastify, opts) {
   const preHandler = opts.preHandler || opts.beforeHandler
   const rewritePrefix = generateRewritePrefix(fastify.prefix, opts)
 
-  const fromOpts = Object.assign({}, opts)
-  fromOpts.base = opts.upstream
-  fromOpts.prefix = undefined
-
   const internalRewriteLocationHeader = opts.internalRewriteLocationHeader ?? true
   const oldRewriteHeaders = (opts.replyOptions || {}).rewriteHeaders
-  const replyOpts = Object.assign({}, opts.replyOptions, {
-    rewriteHeaders
-  })
-  fromOpts.rewriteHeaders = rewriteHeaders
 
-  fastify.register(From, fromOpts)
+  const replyOptions = Object.assign({}, opts.replyOptions)
+  replyOptions.base = opts.upstream
+  replyOptions.rewriteHeaders = rewriteHeaders
+
+  fastify.register(From, replyOptions)
 
   if (opts.proxyPayloads !== false) {
     fastify.addContentTypeParser('application/json', bodyParser)
@@ -313,7 +309,7 @@ async function fastifyHttpProxy (fastify, opts) {
     } else {
       dest = dest.replace(this.prefix, rewritePrefix)
     }
-    reply.from(dest || '/', replyOpts)
+    reply.from(dest || '/', replyOptions)
   }
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -663,9 +663,11 @@ async function run () {
     const server = Fastify()
     server.register(proxy, {
       upstream: `http://localhost:${origin.server.address().port}`,
-      http: {
-        requestOptions: {
-          timeout: 300
+      replyOptions: {
+        http: {
+          requestOptions: {
+            timeout: 300
+          }
         }
       }
     })

--- a/test/ws-prefix-rewrite-core.js
+++ b/test/ws-prefix-rewrite-core.js
@@ -17,7 +17,9 @@ async function proxyServer (t, backendURL, backendPath, proxyOptions, wrapperOpt
   const registerProxy = async fastify => {
     fastify.register(proxy, {
       upstream: backendURL + backendPath,
-      http: true,
+      replyOptions: {
+        http: true
+      },
       ...proxyOptions
     })
   }


### PR DESCRIPTION
Idk why, but @fastify/http-proxy passes to @fastify/reply-from mix-in of its own options and `replyOptions`. Something like that `Object.assign({}, opts, opts.replyOptions)`. Maybe it's a mistake or there are some historical reasons. Anyway it's not specified anywhere, so all @fastify/reply-from options should be passed in opts.replyOptions. It might break some code that relies on that option mixin (see updated test).