### PR TITLE
opt to validate incoming data before proxy is executed

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,21 @@ fastify.addContentTypeParser('application/xml', (req, done) => {
 })
 ```
 
+### `preValidation`
+
+Specify preValidation function to perform the validation of the request before the proxy is executed (e.g. check request payload).
+
+```javascript
+fastify.register(proxy, {
+      upstream: `http://your-target-upstream.com`,
+      preValidation: async (request, reply) => {
+        if (request.body.method !== 'invalid_method') {
+          reply.code(400).send({ message: 'payload contains invalid method' })
+        }
+      }
+    })
+```
+
 ### `config`
 
 An object accessible within the `preHandler` via `reply.context.config`.

--- a/README.md
+++ b/README.md
@@ -27,16 +27,16 @@ npm i @fastify/http-proxy fastify
 ## Example
 
 ```js
-const Fastify = require('fastify')
-const server = Fastify()
+const Fastify = require('fastify');
+const server = Fastify();
 
 server.register(require('@fastify/http-proxy'), {
   upstream: 'http://my-api.example.com',
   prefix: '/api', // optional
-  http2: false // optional
-})
+  http2: false, // optional
+});
 
-server.listen({ port: 3000 })
+server.listen({ port: 3000 });
 ```
 
 This will proxy any request starting with `/api` to `http://my-api.example.com`. For instance `http://localhost:3000/api/users` will be proxied to `http://my-api.example.com/users`.
@@ -44,41 +44,41 @@ This will proxy any request starting with `/api` to `http://my-api.example.com`.
 If you want to have different proxies on different prefixes you can register multiple instances of the plugin as shown in the following snippet:
 
 ```js
-const Fastify = require('fastify')
-const server = Fastify()
-const proxy = require('@fastify/http-proxy')
+const Fastify = require('fastify');
+const server = Fastify();
+const proxy = require('@fastify/http-proxy');
 
 // /api/x will be proxied to http://my-api.example.com/x
 server.register(proxy, {
   upstream: 'http://my-api.example.com',
   prefix: '/api', // optional
-  http2: false // optional
-})
+  http2: false, // optional
+});
 
 // /rest-api/123/endpoint will be proxied to http://my-rest-api.example.com/123/endpoint
 server.register(proxy, {
   upstream: 'http://my-rest-api.example.com',
   prefix: '/rest-api/:id/endpoint', // optional
   rewritePrefix: '/:id/endpoint', // optional
-  http2: false // optional
-})
+  http2: false, // optional
+});
 
 // /auth/user will be proxied to http://single-signon.example.com/signon/user
 server.register(proxy, {
   upstream: 'http://single-signon.example.com',
   prefix: '/auth', // optional
   rewritePrefix: '/signon', // optional
-  http2: false // optional
-})
+  http2: false, // optional
+});
 
 // /user will be proxied to http://single-signon.example.com/signon/user
 server.register(proxy, {
   upstream: 'http://single-signon.example.com',
   rewritePrefix: '/signon', // optional
-  http2: false // optional
-})
+  http2: false, // optional
+});
 
-server.listen({ port: 3000 })
+server.listen({ port: 3000 });
 ```
 
 Notice that in this case it is important to use the `prefix` option to tell the proxy how to properly route the requests across different upstreams.
@@ -92,20 +92,22 @@ For other examples, see [`example.js`](examples/example.js).
 `@fastify/http-proxy` can track and pipe the `request-id` across the upstreams. Using the [`hyperid`](https://www.npmjs.com/package/hyperid) module and the [`@fastify/reply-from`](https://github.com/fastify/fastify-reply-from) built-in options a fairly simple example would look like this:
 
 ```js
-const Fastify = require('fastify')
-const proxy = require('@fastify/http-proxy')
-const hyperid = require('hyperid')
+const Fastify = require('fastify');
+const proxy = require('@fastify/http-proxy');
+const hyperid = require('hyperid');
 
-const server = Fastify()
-const uuid = hyperid()
+const server = Fastify();
+const uuid = hyperid();
 
 server.register(proxy, {
   upstream: 'http://localhost:4001',
   replyOptions: {
-    rewriteRequestHeaders: (originalReq, headers) => ({...headers, 'request-id': uuid()})
-  }
-})
-
+    rewriteRequestHeaders: (originalReq, headers) => ({
+      ...headers,
+      'request-id': uuid(),
+    }),
+  },
+});
 
 server.listen({ port: 3000 });
 ```
@@ -115,8 +117,8 @@ server.listen({ port: 3000 });
 This `fastify` plugin supports _all_ the options of
 [`@fastify/reply-from`](https://github.com/fastify/fastify-reply-from) plus the following.
 
-*Note that this plugin is fully encapsulated, and non-JSON payloads will
-be streamed directly to the destination.*
+_Note that this plugin is fully encapsulated, and non-JSON payloads will
+be streamed directly to the destination._
 
 ### `upstream`
 
@@ -147,9 +149,9 @@ For example, if you are expecting a payload of type `application/xml`, then you 
 
 ```javascript
 fastify.addContentTypeParser('application/xml', (req, done) => {
-  const parsedBody = parsingCode(req)
-  done(null, parsedBody)
-})
+  const parsedBody = parsingCode(req);
+  done(null, parsedBody);
+});
 ```
 
 ### `preValidation`
@@ -158,13 +160,13 @@ Specify preValidation function to perform the validation of the request before t
 
 ```javascript
 fastify.register(proxy, {
-      upstream: `http://your-target-upstream.com`,
-      preValidation: async (request, reply) => {
-        if (request.body.method !== 'invalid_method') {
-          reply.code(400).send({ message: 'payload contains invalid method' })
-        }
-      }
-    })
+  upstream: `http://your-target-upstream.com`,
+  preValidation: async (request, reply) => {
+    if (request.body.method === 'invalid_method') {
+      reply.code(400).send({ message: 'payload contains invalid method' });
+    }
+  },
+});
 ```
 
 ### `config`
@@ -179,6 +181,7 @@ configuration passed to the route.
 Object with [reply options](https://github.com/fastify/fastify-reply-from#replyfromsource-opts) for `@fastify/reply-from`.
 
 ### `internalRewriteLocationHeader`
+
 By default, `@fastify/http-proxy` will rewrite the `location` header when a request redirects to a relative path.
 In other words, the [prefix](https://github.com/fastify/fastify-http-proxy#prefix) will be added to the relative path.
 
@@ -187,12 +190,13 @@ If you want to preserve the original path, this option will disable this interna
 Note that the [rewriteHeaders](https://github.com/fastify/fastify-reply-from#rewriteheadersheaders-request) option of [`@fastify/reply-from`](http://npm.im/fastify-reply-from) will retrieve headers modified (reminder: only `location` is updated among all headers) in parameter but with this option, the headers are unchanged.
 
 ### `httpMethods`
+
 An array that contains the types of the methods. Default: `['DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT', 'OPTIONS']`.
 
 ### `websocket`
 
 This module has _partial_ support for forwarding websockets by passing a
-`websocket` boolean option. 
+`websocket` boolean option.
 
 A few things are missing:
 
@@ -203,6 +207,7 @@ A few things are missing:
 Pull requests are welcome to finish this feature.
 
 ### `wsUpstream`
+
 Working only if property `websocket` is `true`.
 
 An URL (including protocol) that represents the target websockets to use for proxying websockets.
@@ -229,19 +234,19 @@ The default implementation forwards the `cookie` header.
 
 The following benchmarks where generated on a dedicated server with an Intel(R) Core(TM) i7-7700 CPU @ 3.60GHz and 64GB of RAM:
 
-| __Framework__ | req/sec |
-| :----------------- | :------------------------- |
-| `express-http-proxy` | 2557 |
-| `http-proxy` | 9519 |
-| `@fastify/http-proxy` | 15919 |
+| **Framework**         | req/sec |
+| :-------------------- | :------ |
+| `express-http-proxy`  | 2557    |
+| `http-proxy`          | 9519    |
+| `@fastify/http-proxy` | 15919   |
 
 The results were gathered on the second run of `autocannon -c 100 -d 5
 URL`.
 
 ## TODO
 
-* [ ] Perform validations for incoming data
-* [ ] Finish implementing websocket
+- [ ] Perform validations for incoming data
+- [ ] Finish implementing websocket
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -260,13 +260,11 @@ async function fastifyHttpProxy (fastify, opts) {
 
   fastify.register(From, fromOpts)
 
-  if (opts.preValidation === undefined && opts.proxyPayloads !== false) {
-    fastify.addContentTypeParser('application/json', bodyParser)
-    fastify.addContentTypeParser('*', bodyParser)
-  }
-
   if (opts.preValidation) {
     fastify.addHook('preValidation', opts.preValidation)
+  } else if (opts.proxyPayloads !== false) {
+    fastify.addContentTypeParser('application/json', bodyParser)
+    fastify.addContentTypeParser('*', bodyParser)
   }
 
   function rewriteHeaders (headers, req) {

--- a/index.js
+++ b/index.js
@@ -5,15 +5,7 @@ const WebSocket = require('ws')
 const { convertUrlToWebSocket } = require('./utils')
 const fp = require('fastify-plugin')
 
-const httpMethods = [
-  'DELETE',
-  'GET',
-  'HEAD',
-  'PATCH',
-  'POST',
-  'PUT',
-  'OPTIONS'
-]
+const httpMethods = ['DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT', 'OPTIONS']
 const urlPattern = /^https?:\/\//
 const kWs = Symbol('ws')
 const kWsHead = Symbol('wsHead')
@@ -57,28 +49,26 @@ function proxyWebSockets (source, target) {
     closeWebSocket(target, code, reason)
   }
 
-  source.on('message', (data, binary) =>
-    waitConnection(target, () => target.send(data, { binary }))
-  )
+  source.on('message', (data, binary) => waitConnection(target, () => target.send(data, { binary })))
   /* istanbul ignore next */
-  source.on('ping', (data) => waitConnection(target, () => target.ping(data)))
+  source.on('ping', data => waitConnection(target, () => target.ping(data)))
   /* istanbul ignore next */
-  source.on('pong', (data) => waitConnection(target, () => target.pong(data)))
+  source.on('pong', data => waitConnection(target, () => target.pong(data)))
   source.on('close', close)
   /* istanbul ignore next */
-  source.on('error', (error) => close(1011, error.message))
+  source.on('error', error => close(1011, error.message))
   /* istanbul ignore next */
   source.on('unexpected-response', () => close(1011, 'unexpected response'))
 
   // source WebSocket is already connected because it is created by ws server
   target.on('message', (data, binary) => source.send(data, { binary }))
   /* istanbul ignore next */
-  target.on('ping', (data) => source.ping(data))
+  target.on('ping', data => source.ping(data))
   /* istanbul ignore next */
-  target.on('pong', (data) => source.pong(data))
+  target.on('pong', data => source.pong(data))
   target.on('close', close)
   /* istanbul ignore next */
-  target.on('error', (error) => close(1011, error.message))
+  target.on('error', error => close(1011, error.message))
   /* istanbul ignore next */
   target.on('unexpected-response', () => close(1011, 'unexpected response'))
 }
@@ -107,15 +97,10 @@ class WebSocketProxy {
     })
 
     this.handleUpgrade = (request, cb) => {
-      wss.handleUpgrade(
-        request.raw,
-        request.raw[kWs],
-        request.raw[kWsHead],
-        (socket) => {
-          this.handleConnection(socket, request)
-          cb()
-        }
-      )
+      wss.handleUpgrade(request.raw, request.raw[kWs], request.raw[kWsHead], (socket) => {
+        this.handleConnection(socket, request)
+        cb()
+      })
     }
 
     // To be able to close the HTTP server,
@@ -164,13 +149,7 @@ class WebSocketProxy {
   findUpstream (request) {
     const source = new URL(request.url, 'ws://127.0.0.1')
 
-    for (const {
-      prefix,
-      rewritePrefix,
-      upstream,
-      wsUpstream,
-      wsClientOptions
-    } of this.prefixList) {
+    for (const { prefix, rewritePrefix, upstream, wsUpstream, wsClientOptions } of this.prefixList) {
       if (wsUpstream) {
         const target = new URL(wsUpstream)
         target.search = source.search
@@ -178,26 +157,20 @@ class WebSocketProxy {
       }
 
       if (source.pathname.startsWith(prefix)) {
-        const target = new URL(
-          source.pathname.replace(prefix, rewritePrefix),
-          upstream
-        )
+        const target = new URL(source.pathname.replace(prefix, rewritePrefix), upstream)
         target.search = source.search
         return { target, wsClientOptions }
       }
     }
 
     /* istanbul ignore next */
-    throw new Error(
-      `no upstream found for ${request.url}. this should not happened. Please report to https://github.com/fastify/fastify-http-proxy`
-    )
+    throw new Error(`no upstream found for ${request.url}. this should not happened. Please report to https://github.com/fastify/fastify-http-proxy`)
   }
 
   handleConnection (source, request) {
     const upstream = this.findUpstream(request)
     const { target: url, wsClientOptions } = upstream
-    const rewriteRequestHeaders =
-      wsClientOptions?.rewriteRequestHeaders || defaultWsHeadersRewrite
+    const rewriteRequestHeaders = wsClientOptions?.rewriteRequestHeaders || defaultWsHeadersRewrite
     const headersToRewrite = wsClientOptions?.headers || {}
 
     const subprotocols = []
@@ -257,9 +230,7 @@ function setupWebSocketProxy (fastify, options, rewritePrefix) {
 }
 
 function generateRewritePrefix (prefix, opts) {
-  let rewritePrefix =
-    opts.rewritePrefix ||
-    (opts.upstream ? new URL(opts.upstream).pathname : '/')
+  let rewritePrefix = opts.rewritePrefix || (opts.upstream ? new URL(opts.upstream).pathname : '/')
 
   if (!prefix.endsWith('/') && rewritePrefix.endsWith('/')) {
     rewritePrefix = rewritePrefix.slice(0, -1)
@@ -269,14 +240,7 @@ function generateRewritePrefix (prefix, opts) {
 }
 
 async function fastifyHttpProxy (fastify, opts) {
-  if (
-    !opts.upstream &&
-    !(
-      opts.upstream === '' &&
-      opts.replyOptions &&
-      typeof opts.replyOptions.getUpstream === 'function'
-    )
-  ) {
+  if (!opts.upstream && !(opts.upstream === '' && opts.replyOptions && typeof opts.replyOptions.getUpstream === 'function')) {
     throw new Error('upstream must be specified')
   }
 
@@ -287,8 +251,7 @@ async function fastifyHttpProxy (fastify, opts) {
   fromOpts.base = opts.upstream
   fromOpts.prefix = undefined
 
-  const internalRewriteLocationHeader =
-    opts.internalRewriteLocationHeader ?? true
+  const internalRewriteLocationHeader = opts.internalRewriteLocationHeader ?? true
   const oldRewriteHeaders = (opts.replyOptions || {}).rewriteHeaders
   const replyOpts = Object.assign({}, opts.replyOptions, {
     rewriteHeaders
@@ -356,24 +319,15 @@ async function fastifyHttpProxy (fastify, opts) {
       return
     }
     const queryParamIndex = request.raw.url.indexOf('?')
-    let dest = request.raw.url.slice(
-      0,
-      queryParamIndex !== -1 ? queryParamIndex : undefined
-    )
+    let dest = request.raw.url.slice(0, queryParamIndex !== -1 ? queryParamIndex : undefined)
 
     if (this.prefix.includes(':')) {
       const requestedPathElements = request.url.split('/')
-      const prefixPathWithVariables = this.prefix
-        .split('/')
-        .map((_, index) => requestedPathElements[index])
-        .join('/')
+      const prefixPathWithVariables = this.prefix.split('/').map((_, index) => requestedPathElements[index]).join('/')
 
       let rewritePrefixWithVariables = rewritePrefix
       for (const [name, value] of Object.entries(request.params)) {
-        rewritePrefixWithVariables = rewritePrefixWithVariables.replace(
-          `:${name}`,
-          value
-        )
+        rewritePrefixWithVariables = rewritePrefixWithVariables.replace(`:${name}`, value)
       }
 
       dest = dest.replace(prefixPathWithVariables, rewritePrefixWithVariables)

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,6 @@
 /// <reference types='node' />
 
-import { FastifyPluginCallback, preHandlerHookHandler } from 'fastify';
+import { FastifyPluginCallback, preHandlerHookHandler, preValidationHookHandler } from 'fastify';
 
 import {
   FastifyReplyFromOptions,
@@ -31,6 +31,7 @@ declare namespace fastifyHttpProxy {
     proxyPayloads?: boolean;
     preHandler?: preHandlerHookHandler;
     beforeHandler?: preHandlerHookHandler;
+    preValidation?: preValidationHookHandler;
     config?: Object;
     replyOptions?: FastifyReplyFromHooks;
     wsClientOptions?: ClientOptions;

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,11 +1,14 @@
-import fastify, { RawReplyDefaultExpression, RawRequestDefaultExpression } from 'fastify';
+import fastify, {
+  RawReplyDefaultExpression,
+  RawRequestDefaultExpression,
+} from 'fastify';
 import { expectError, expectType } from 'tsd';
 import fastifyHttpProxy from '..';
 
 const app = fastify();
 
 app.register(fastifyHttpProxy, {
-  upstream: 'http://origin.asd'
+  upstream: 'http://origin.asd',
 });
 
 app.register(fastifyHttpProxy, {
@@ -24,6 +27,10 @@ app.register(fastifyHttpProxy, {
     expectType<RawRequestDefaultExpression>(request.raw);
     expectType<RawReplyDefaultExpression>(reply.raw);
   },
+  preValidation: (request, reply) => {
+    expectType<RawRequestDefaultExpression>(request.raw);
+    expectType<RawReplyDefaultExpression>(reply.raw);
+  },
   base: 'whatever',
   cacheURLs: 10,
   undici: {
@@ -31,32 +38,32 @@ app.register(fastifyHttpProxy, {
     pipelining: 1,
     keepAliveTimeout: 60 * 1000,
     connect: {
-      rejectUnauthorized: false
-    }
+      rejectUnauthorized: false,
+    },
   },
   http: {
     agentOptions: {
-      keepAliveMsecs: 10 * 60 * 1000
+      keepAliveMsecs: 10 * 60 * 1000,
     },
     requestOptions: {
-      timeout: 20000
-    }
+      timeout: 20000,
+    },
   },
   constraints: { version: '1.0.2' },
   websocket: true,
-  wsUpstream: 'ws://origin.asd/connection'
+  wsUpstream: 'ws://origin.asd/connection',
 });
 
 expectError(
   app.register(fastifyHttpProxy, {
-    thisOptionDoesNotExist: 'triggers a typescript error'
+    thisOptionDoesNotExist: 'triggers a typescript error',
   })
 );
 
 expectError(
   app.register(fastifyHttpProxy, {
     upstream: 'http://origin.asd',
-    wsUpstream: 'ws://origin.asd'
+    wsUpstream: 'ws://origin.asd',
   })
 );
 
@@ -64,6 +71,6 @@ expectError(
   app.register(fastifyHttpProxy, {
     upstream: 'http://origin.asd',
     websocket: false,
-    wsUpstream: 'asdf'
+    wsUpstream: 'asdf',
   })
 );


### PR DESCRIPTION
Provide an option to preValidate incoming data (check out: https://github.com/fastify/fastify-http-proxy/issues/311)

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
