### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/benchmarks/http-proxy.js
+++ b/benchmarks/http-proxy.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const httpProxy = require('http-proxy')
-const { Agent } = require('http')
+const { Agent } = require('node:http')
 
 const proxy = httpProxy.createProxyServer({
   target: 'http://localhost:3001',

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 const From = require('@fastify/reply-from')
-const { ServerResponse } = require('http')
+const { ServerResponse } = require('node:http')
 const WebSocket = require('ws')
 const { convertUrlToWebSocket } = require('./utils')
 const fp = require('fastify-plugin')

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -5,9 +5,9 @@ const Fastify = require('fastify')
 const proxy = require('../')
 const ioServer = require('socket.io')
 const ioClient = require('socket.io-client')
-const { createServer } = require('http')
-const { promisify } = require('util')
-const { once } = require('events')
+const { createServer } = require('node:http')
+const { promisify } = require('node:util')
+const { once } = require('node:events')
 
 test('proxy socket.io', async t => {
   t.plan(2)

--- a/test/test.js
+++ b/test/test.js
@@ -5,7 +5,7 @@ const Fastify = require('fastify')
 const proxy = require('../')
 const got = require('got')
 const { Unauthorized } = require('http-errors')
-const Transform = require('stream').Transform
+const Transform = require('node:stream').Transform
 
 async function run () {
   const origin = Fastify()

--- a/test/websocket.js
+++ b/test/websocket.js
@@ -4,9 +4,9 @@ const { test } = require('tap')
 const Fastify = require('fastify')
 const proxy = require('../')
 const WebSocket = require('ws')
-const { createServer } = require('http')
-const { promisify } = require('util')
-const { once } = require('events')
+const { createServer } = require('node:http')
+const { promisify } = require('node:util')
+const { once } = require('node:events')
 const cookieValue = 'foo=bar'
 const subprotocolValue = 'foo-subprotocol'
 

--- a/test/ws-prefix-rewrite-core.js
+++ b/test/ws-prefix-rewrite-core.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const t = require('tap')
-const { once } = require('events')
+const { once } = require('node:events')
 
 const Fastify = require('fastify')
 const fastifyWebSocket = require('@fastify/websocket')

--- a/test/ws-prefix-rewrite.js
+++ b/test/ws-prefix-rewrite.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const t = require('tap')
-const { once } = require('events')
+const { once } = require('node:events')
 
 const Fastify = require('fastify')
 const fastifyWebSocket = require('@fastify/websocket')


### PR DESCRIPTION
See https://github.com/fastify/fastify-static/pull/407

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
