### PR TITLE
chore: replace `fastify.io` links with `fastify.dev`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://standardjs.com/)
 
 Proxy your HTTP requests to another server, with hooks.
-This [`fastify`](https://www.fastify.io) plugin forwards all requests
+This [`fastify`](https://www.fastify.dev) plugin forwards all requests
 received with a given prefix (or none) to an upstream. All Fastify hooks are still applied.
 
 `@fastify/http-proxy` is built on top of
@@ -172,7 +172,7 @@ fastify.register(proxy, {
 ### `config`
 
 An object accessible within the `preHandler` via `reply.context.config`.
-See [Config](https://www.fastify.io/docs/v4.8.x/Reference/Routes/#config) in the Fastify
+See [Config](https://www.fastify.dev/docs/v4.8.x/Reference/Routes/#config) in the Fastify
 documentation for information on this option. Note: this is merged with other
 configuration passed to the route.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://standardjs.com/)
 
 Proxy your HTTP requests to another server, with hooks.
-This [`fastify`](https://www.fastify.dev) plugin forwards all requests
+This [`fastify`](https://fastify.dev) plugin forwards all requests
 received with a given prefix (or none) to an upstream. All Fastify hooks are still applied.
 
 `@fastify/http-proxy` is built on top of
@@ -172,7 +172,7 @@ fastify.register(proxy, {
 ### `config`
 
 An object accessible within the `preHandler` via `reply.context.config`.
-See [Config](https://www.fastify.dev/docs/v4.8.x/Reference/Routes/#config) in the Fastify
+See [Config](https://fastify.dev/docs/v4.8.x/Reference/Routes/#config) in the Fastify
 documentation for information on this option. Note: this is merged with other
 configuration passed to the route.
 

--- a/examples/example.js
+++ b/examples/example.js
@@ -11,7 +11,7 @@ async function startOrigin () {
   })
 
   origin.get('/redirect', async (request, reply) => {
-    return reply.redirect(302, 'https://fastify.io')
+    return reply.redirect(302, 'https://fastify.dev')
   })
 
   origin.get('/a', async (request, reply) => {

--- a/test/test.js
+++ b/test/test.js
@@ -19,7 +19,7 @@ async function run () {
   })
 
   origin.get('/redirect', async (request, reply) => {
-    return reply.redirect(302, 'https://fastify.io')
+    return reply.redirect(302, 'https://fastify.dev')
   })
 
   origin.post('/this-has-data', async (request, reply) => {
@@ -121,7 +121,7 @@ async function run () {
         followRedirect: false
       }
     )
-    t.equal(location, 'https://fastify.io')
+    t.equal(location, 'https://fastify.dev')
     t.equal(statusCode, 302)
   })
 
@@ -147,7 +147,7 @@ async function run () {
         followRedirect: false
       }
     )
-    t.equal(location, 'https://fastify.io')
+    t.equal(location, 'https://fastify.dev')
     t.equal(statusCode, 302)
   })
 


### PR DESCRIPTION
See https://github.com/fastify/ajv-compiler/pull/115

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
