### PR TITLE
Add WebSocket host constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,9 +219,6 @@ Note that if property `wsUpstream` not specified then proxy will try to connect 
 
 The options passed to [`new ws.Server()`](https://github.com/websockets/ws/blob/HEAD/doc/ws.md#class-websocketserver).
 
-In case multiple websocket proxies are attached to the same HTTP server at different paths.
-In this case, only the first `wsServerOptions` is applied.
-
 ### `wsClientOptions`
 
 The options passed to the [`WebSocket` constructor](https://github.com/websockets/ws/blob/HEAD/doc/ws.md#class-websocket) for outgoing websockets.

--- a/index.js
+++ b/index.js
@@ -150,20 +150,25 @@ class WebSocketProxy {
   }
 
   findUpstream (request, dest) {
+    const search = new URL(request.url, 'ws://127.0.0.1').search
+
     if (typeof this.wsUpstream === 'string' && this.wsUpstream !== '') {
       const target = new URL(this.wsUpstream)
-      target.search = new URL(request.url, 'ws://127.0.0.1').search
+      target.search = search
       return target
     }
 
     if (typeof this.upstream === 'string' && this.upstream !== '') {
-      return new URL(dest, this.upstream)
+      const target = new URL(dest, this.upstream)
+      target.search = search
+      return target
     }
 
     const upstream = this.getUpstream(request, '')
     const target = new URL(dest, upstream)
     /* istanbul ignore next */
     target.protocol = upstream.indexOf('http:') === 0 ? 'ws:' : 'wss'
+    target.search = search
     return target
   }
 

--- a/test/websocket.js
+++ b/test/websocket.js
@@ -564,6 +564,8 @@ test('multiple websocket upstreams with distinct server options', async (t) => {
       { headers: { host: name } }
     )
     await once(ws, 'open')
+    ws.send(`hello ${name}`)
+    await once(ws, 'message')
     wsClients.push(ws)
   }
 

--- a/test/websocket.js
+++ b/test/websocket.js
@@ -474,3 +474,100 @@ test('Proxy websocket with custom upstream url', async (t) => {
     server.close()
   ])
 })
+
+test('multiple websocket upstreams with host constraints', async (t) => {
+  t.plan(4)
+
+  const server = Fastify()
+
+  for (const name of ['foo', 'bar']) {
+    const origin = createServer()
+    const wss = new WebSocket.Server({ server: origin })
+    t.teardown(wss.close.bind(wss))
+    t.teardown(origin.close.bind(origin))
+
+    wss.once('connection', (ws) => {
+      ws.once('message', message => {
+        t.equal(message.toString(), `hello ${name}`)
+        // echo
+        ws.send(message)
+      })
+    })
+
+    await promisify(origin.listen.bind(origin))({ port: 0, host: '127.0.0.1' })
+    server.register(proxy, {
+      upstream: `ws://127.0.0.1:${origin.address().port}`,
+      websocket: true,
+      constraints: { host: name }
+    })
+  }
+
+  await server.listen({ port: 0, host: '127.0.0.1' })
+  t.teardown(server.close.bind(server))
+
+  const wsClients = []
+  for (const name of ['foo', 'bar']) {
+    const ws = new WebSocket(`ws://127.0.0.1:${server.server.address().port}`, { headers: { host: name } })
+    await once(ws, 'open')
+    ws.send(`hello ${name}`)
+    const [reply] = await once(ws, 'message')
+    t.equal(reply.toString(), `hello ${name}`)
+    wsClients.push(ws)
+  }
+
+  await Promise.all([
+    ...wsClients.map(ws => once(ws, 'close')),
+    server.close()
+  ])
+})
+
+test('multiple websocket upstreams with distinct server options', async (t) => {
+  t.plan(2)
+
+  const server = Fastify()
+
+  for (const name of ['foo', 'bar']) {
+    const origin = createServer()
+    const wss = new WebSocket.Server({ server: origin })
+    t.teardown(wss.close.bind(wss))
+    t.teardown(origin.close.bind(origin))
+
+    wss.once('connection', (ws) => {
+      ws.once('message', message => {
+        // echo
+        ws.send(message)
+      })
+    })
+
+    await promisify(origin.listen.bind(origin))({ port: 0, host: '127.0.0.1' })
+    server.register(proxy, {
+      upstream: `ws://127.0.0.1:${origin.address().port}`,
+      websocket: true,
+      constraints: { host: name },
+      wsServerOptions: {
+        verifyClient: ({ req }) => {
+          t.equal(req.url, `/?q=${name}`)
+          return true
+        }
+      }
+    })
+  }
+
+  await server.listen({ port: 0, host: '127.0.0.1' })
+  t.teardown(server.close.bind(server))
+
+  const wsClients = []
+  for (const name of ['foo', 'bar']) {
+    const ws = new WebSocket(
+      `ws://127.0.0.1:${server.server.address().port}/?q=${name}`,
+      { headers: { host: name } }
+    )
+    await once(ws, 'open')
+    wsClients.push(ws)
+  }
+
+  await Promise.all([
+    ...wsClients.map(ws => once(ws, 'close')),
+    server.close()
+  ])
+})

--- a/test/websocket.js
+++ b/test/websocket.js
@@ -522,7 +522,7 @@ test('multiple websocket upstreams with host constraints', async (t) => {
 })
 
 test('multiple websocket upstreams with distinct server options', async (t) => {
-  t.plan(2)
+  t.plan(4)
 
   const server = Fastify()
 
@@ -532,7 +532,8 @@ test('multiple websocket upstreams with distinct server options', async (t) => {
     t.teardown(wss.close.bind(wss))
     t.teardown(origin.close.bind(origin))
 
-    wss.once('connection', (ws) => {
+    wss.once('connection', (ws, req) => {
+      t.equal(req.url, `/?q=${name}`)
       ws.once('message', message => {
         // echo
         ws.send(message)


### PR DESCRIPTION
Fixes 2 issues:
- mismatch between Http and WebSocket routing
  - WebSockets now support constraints
  - WebSockets now use the same path rewriting logic as Http
- `wsServerOptions` are now distinct for each WebSocket proxy

Fixes: #206 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
