### PR TITLE
Keep websocket path on proxy

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,11 +150,12 @@ class WebSocketProxy {
   }
 
   findUpstream (request, dest) {
-    const search = new URL(request.url, 'ws://127.0.0.1').search
+    const { search, pathname } = new URL(request.url, 'ws://127.0.0.1')
 
     if (typeof this.wsUpstream === 'string' && this.wsUpstream !== '') {
       const target = new URL(this.wsUpstream)
       target.search = search
+      target.pathname = target.pathname === '/' ? pathname : target.pathname
       return target
     }
 

--- a/test/websocket.js
+++ b/test/websocket.js
@@ -574,3 +574,70 @@ test('multiple websocket upstreams with distinct server options', async (t) => {
     server.close()
   ])
 })
+
+test('keep proxy websocket pathname', async (t) => {
+  t.plan(5)
+
+  const origin = createServer()
+  const wss = new WebSocket.Server({ server: origin })
+
+  t.teardown(wss.close.bind(wss))
+  t.teardown(origin.close.bind(origin))
+
+  const serverMessages = []
+  wss.on('connection', (ws, request) => {
+    ws.on('message', (message, binary) => {
+      // Also need save request.url for check from what url the message is coming.
+      serverMessages.push([message.toString(), binary, request.headers.host.split(':', 1)[0], request.url])
+      ws.send(message, { binary })
+    })
+  })
+
+  await promisify(origin.listen.bind(origin))({ port: 0, host: '127.0.0.1' })
+  // Host for wsUpstream and for later check.
+  const host = '127.0.0.1'
+  // Path for wsUpstream and for later check.
+  const path = '/keep/path'
+  const server = Fastify()
+  server.register(proxy, {
+    upstream: `ws://127.0.0.1:${origin.address().port}`,
+    // Start proxy with different upstream, without path
+    wsUpstream: `ws://${host}:${origin.address().port}`,
+    websocket: true
+  })
+
+  await server.listen({ port: 0, host: '127.0.0.1' })
+  t.teardown(server.close.bind(server))
+
+  // Start websocket with different upstream for connect, added path.
+  const ws = new WebSocket(`ws://${host}:${server.server.address().port}${path}`)
+  await once(ws, 'open')
+
+  const data = [{ message: 'hello', binary: false }, { message: 'fastify', binary: true, isBuffer: true }]
+  const dataLength = data.length
+  let dataIndex = 0
+
+  for (; dataIndex < dataLength; dataIndex++) {
+    const { message: msg, binary, isBuffer } = data[dataIndex]
+    const message = isBuffer
+      ? Buffer.from(msg)
+      : msg
+
+    ws.send(message, { binary })
+
+    const [reply, binaryAnswer] = await once(ws, 'message')
+
+    t.equal(reply.toString(), msg)
+    t.equal(binaryAnswer, binary)
+  }
+  // Also check "path", must be the same.
+  t.strictSame(serverMessages, [
+    ['hello', false, host, path],
+    ['fastify', true, host, path]
+  ])
+
+  await Promise.all([
+    once(ws, 'close'),
+    server.close()
+  ])
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)


Please understand if there is something I don't understand.

This is a fix for the part where the websocket path cannot be passed as is.
I have added the example and proxying part below.

for example)
wsUpstream: ws://localhost:3030
1. ws://proxyhost/keep/path > ws://localhost:3030/keep/path
2. ws://proxyhost/keep2/path > ws://localhost:3030/keep2/path