### PR TITLE
chore: remove unused make-promises-safe

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "got": "^11.8.3",
     "http-errors": "^2.0.0",
     "http-proxy": "^1.18.1",
-    "make-promises-safe": "^5.1.0",
     "simple-get": "^4.0.0",
     "snazzy": "^9.0.0",
     "socket.io": "^4.4.1",

--- a/test/test.js
+++ b/test/test.js
@@ -382,7 +382,7 @@ async function run () {
       upstream: `http://localhost:${origin.server.address().port}`,
       config: { foo: 'bar' },
       async preHandler (request, reply) {
-        t.same(reply.context.config, {
+        t.same(request.routeOptions.config, {
           foo: 'bar',
           url: '/',
           method: [


### PR DESCRIPTION
make-promises-safe doesn't appear to have actually been in use.

I also updated a test that was access the deprecated `reply.context.config`


#### Checklist

- [x] run `npm run test`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
