### PR TITLE
feat: allow overriding or modifying the queryString for websockets

### DIFF
--- a/index.js
+++ b/index.js
@@ -175,6 +175,9 @@ class WebSocketProxy {
 
   handleConnection (source, request, dest) {
     const url = this.findUpstream(request, dest)
+    const queryString = getQueryString(url.search, request.url, this.wsClientOptions, request)
+    url.search = queryString
+
     const rewriteRequestHeaders = this.wsClientOptions.rewriteRequestHeaders
     const headersToRewrite = this.wsClientOptions.headers
 
@@ -190,6 +193,22 @@ class WebSocketProxy {
     this.logger.debug({ url: url.href }, 'proxy websocket')
     proxyWebSockets(source, target)
   }
+}
+
+function getQueryString (search, reqUrl, opts, request) {
+  if (typeof opts.queryString === 'function') {
+    return '?' + opts.queryString(search, reqUrl, request)
+  }
+
+  if (opts.queryString) {
+    return '?' + qs.stringify(opts.queryString)
+  }
+
+  if (search.length > 0) {
+    return search
+  }
+
+  return ''
 }
 
 function defaultWsHeadersRewrite (headers, request) {

--- a/test/websocket-querystring.js
+++ b/test/websocket-querystring.js
@@ -1,0 +1,126 @@
+'use strict'
+
+const { test } = require('tap')
+const Fastify = require('fastify')
+const proxy = require('../')
+const WebSocket = require('ws')
+const { createServer } = require('node:http')
+const { promisify } = require('node:util')
+const { once } = require('node:events')
+const qs = require('fast-querystring')
+
+const subprotocolValue = 'foo-subprotocol'
+
+test('websocket proxy with object queryString', async (t) => {
+  t.plan(7)
+
+  const origin = createServer()
+  const wss = new WebSocket.Server({ server: origin })
+  t.teardown(wss.close.bind(wss))
+  t.teardown(origin.close.bind(origin))
+
+  const serverMessages = []
+  wss.on('connection', (ws, request) => {
+    t.equal(ws.protocol, subprotocolValue)
+    t.equal(request.url, '/?q=test')
+    ws.on('message', (message, binary) => {
+      serverMessages.push([message.toString(), binary])
+      // echo
+      ws.send(message, { binary })
+    })
+  })
+
+  await promisify(origin.listen.bind(origin))({ port: 0, host: '127.0.0.1' })
+
+  const server = Fastify()
+  server.register(proxy, {
+    upstream: `ws://127.0.0.1:${origin.address().port}`,
+    websocket: true,
+    wsClientOptions: {
+      queryString: { q: 'test' }
+    }
+  })
+
+  await server.listen({ port: 0, host: '127.0.0.1' })
+  t.teardown(server.close.bind(server))
+
+  const ws = new WebSocket(`ws://127.0.0.1:${server.server.address().port}`, [subprotocolValue])
+  await once(ws, 'open')
+
+  ws.send('hello', { binary: false })
+  const [reply0, binary0] = await once(ws, 'message')
+  t.equal(reply0.toString(), 'hello')
+  t.equal(binary0, false)
+
+  ws.send(Buffer.from('fastify'), { binary: true })
+  const [reply1, binary1] = await once(ws, 'message')
+  t.equal(reply1.toString(), 'fastify')
+  t.equal(binary1, true)
+
+  t.strictSame(serverMessages, [
+    ['hello', false],
+    ['fastify', true]
+  ])
+
+  await Promise.all([
+    once(ws, 'close'),
+    server.close()
+  ])
+})
+
+test('websocket proxy with function queryString', async (t) => {
+  t.plan(7)
+
+  const origin = createServer()
+  const wss = new WebSocket.Server({ server: origin })
+  t.teardown(wss.close.bind(wss))
+  t.teardown(origin.close.bind(origin))
+
+  const serverMessages = []
+  wss.on('connection', (ws, request) => {
+    t.equal(ws.protocol, subprotocolValue)
+    t.equal(request.url, '/?q=test')
+    ws.on('message', (message, binary) => {
+      serverMessages.push([message.toString(), binary])
+      // echo
+      ws.send(message, { binary })
+    })
+  })
+
+  await promisify(origin.listen.bind(origin))({ port: 0, host: '127.0.0.1' })
+
+  const server = Fastify()
+  server.register(proxy, {
+    upstream: `ws://127.0.0.1:${origin.address().port}`,
+    websocket: true,
+    wsClientOptions: {
+      queryString: () => qs.stringify({ q: 'test' })
+    }
+  })
+
+  await server.listen({ port: 0, host: '127.0.0.1' })
+  t.teardown(server.close.bind(server))
+
+  const ws = new WebSocket(`ws://127.0.0.1:${server.server.address().port}`, [subprotocolValue])
+  await once(ws, 'open')
+
+  ws.send('hello', { binary: false })
+  const [reply0, binary0] = await once(ws, 'message')
+  t.equal(reply0.toString(), 'hello')
+  t.equal(binary0, false)
+
+  ws.send(Buffer.from('fastify'), { binary: true })
+  const [reply1, binary1] = await once(ws, 'message')
+  t.equal(reply1.toString(), 'fastify')
+  t.equal(binary1, true)
+
+  t.strictSame(serverMessages, [
+    ['hello', false],
+    ['fastify', true]
+  ])
+
+  await Promise.all([
+    once(ws, 'close'),
+    server.close()
+  ])
+})

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,13 @@
 /// <reference types='node' />
 
-import { FastifyPluginCallback, preHandlerHookHandler, preValidationHookHandler } from 'fastify';
+import {
+  FastifyPluginCallback,
+  FastifyRequest,
+  preHandlerHookHandler,
+  preValidationHookHandler,
+  RawServerBase,
+  RequestGenericInterface,
+} from 'fastify';
 
 import {
   FastifyReplyFromOptions,
@@ -24,6 +31,12 @@ type FastifyHttpProxy = FastifyPluginCallback<
 >;
 
 declare namespace fastifyHttpProxy {
+  type QueryStringFunction = (
+    search: string | undefined,
+    reqUrl: string,
+    request: FastifyRequest<RequestGenericInterface, RawServerBase>
+  ) => string;
+
   export interface FastifyHttpProxyOptions extends FastifyReplyFromOptions {
     upstream: string;
     prefix?: string;
@@ -34,7 +47,7 @@ declare namespace fastifyHttpProxy {
     preValidation?: preValidationHookHandler;
     config?: Object;
     replyOptions?: FastifyReplyFromHooks;
-    wsClientOptions?: ClientOptions;
+    wsClientOptions?: ClientOptions & { queryString?: { [key: string]: unknown } | QueryStringFunction; };
     wsServerOptions?: ServerOptions;
     httpMethods?: string[];
     constraints?: { [name: string]: any };

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,6 +1,9 @@
 import fastify, {
   RawReplyDefaultExpression,
   RawRequestDefaultExpression,
+  type FastifyRequest,
+  type RawServerBase,
+  type RequestGenericInterface,
 } from 'fastify';
 import { expectError, expectType } from 'tsd';
 import fastifyHttpProxy from '..';
@@ -52,6 +55,14 @@ app.register(fastifyHttpProxy, {
   constraints: { version: '1.0.2' },
   websocket: true,
   wsUpstream: 'ws://origin.asd/connection',
+  wsClientOptions: {
+    queryString(search, reqUrl, request) {
+      expectType<string | undefined>(search);
+      expectType<string>(reqUrl);
+      expectType<FastifyRequest<RequestGenericInterface, RawServerBase>>(request);
+      return '';
+    },
+  },
   internalRewriteLocationHeader: true,
 });
 


### PR DESCRIPTION
Allow overriding or modifying the queryString when proxying websockets.

Fixes: #348

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
