### PR TITLE
fix:  allow for getUpstream flow for empty wsUpstream option

### DIFF
--- a/index.js
+++ b/index.js
@@ -229,7 +229,7 @@ function generateRewritePrefix (prefix, opts) {
 }
 
 async function fastifyHttpProxy (fastify, opts) {
-  if (!opts.upstream && !(opts.upstream === '' && opts.replyOptions && typeof opts.replyOptions.getUpstream === 'function')) {
+  if (!opts.upstream && !opts.websocket && !((opts.upstream === '' || opts.wsUpstream === '') && opts.replyOptions && typeof opts.replyOptions.getUpstream === 'function')) {
     throw new Error('upstream must be specified')
   }
 

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ class WebSocketProxy {
       headers: {},
       ...wsClientOptions
     }
-    this.upstream = convertUrlToWebSocket(upstream)
+    this.upstream = upstream ? convertUrlToWebSocket(upstream) : ''
     this.wsUpstream = wsUpstream ? convertUrlToWebSocket(wsUpstream) : ''
     this.getUpstream = getUpstream
 


### PR DESCRIPTION
Resolves #333 

This fix makes using `wsUpstream: ''` with a set `replyOptions.getUpstream` consistent with the established flow of using `upstream: ''` with a `getUpstream` set. To do so, just some added logic to the plugin initialization phase as well as updating the WebsocketProxy constructor logic. Note, I maintained the need for the `websocket` flag needing to be set to `true` to remain consistent with the proxying of websockets currently.

This should also allow for dynamically setting a websocket upstream through the use of the websocket options provided, which should be a bit more clear for those wanting that behavior.


#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
