### PR TITLE
Test: Fastify #5555 - move to node test runner

### DIFF
--- a/.borp.yaml
+++ b/.borp.yaml
@@ -1,0 +1,2 @@
+files:
+  - 'test/**/*.js'

--- a/.taprc
+++ b/.taprc
@@ -1,2 +1,0 @@
-files:
-  - test/**/*.js

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "lint:typescript": "npm run lint:fix - --parser @typescript-eslint/parser --plugin typescript \"test/types/*.ts\"",
-    "test": "npm run lint && tap \"test/*.js\" && npm run typescript",
+    "test": "npm run lint && borp -C --check-coverage --reporter=@jsumners/line-reporter && npm run typescript",
     "typescript": "tsd"
   },
   "repository": {
@@ -59,8 +59,10 @@
   "devDependencies": {
     "@fastify/pre-commit": "^2.1.0",
     "@fastify/websocket": "^11.0.1",
+    "@jsumners/line-reporter": "^1.0.1",
     "@types/node": "^22.0.0",
     "@types/ws": "^8.5.10",
+    "borp": "^0.19.0",
     "eslint": "^9.17.0",
     "express": "^4.19.2",
     "express-http-proxy": "^2.0.0",
@@ -73,7 +75,6 @@
     "simple-get": "^4.0.1",
     "socket.io": "^4.7.5",
     "socket.io-client": "^4.7.5",
-    "tap": "^18.7.2",
     "tsd": "^0.31.0",
     "typescript": "~5.7.2",
     "why-is-node-running": "^3.0.0"

--- a/test/export.js
+++ b/test/export.js
@@ -8,15 +8,15 @@ const { fastifyHttpProxy: namedExport } = require('..')
 
 test('module export', function (t) {
   t.plan(1)
-  t.assert.equal(typeof fastifyHttpProxy, 'function')
+  t.assert.strictEqual(typeof fastifyHttpProxy, 'function')
 })
 
 test('default export', function (t) {
   t.plan(1)
-  t.assert.equal(typeof defaultExport, 'function')
+  t.assert.strictEqual(typeof defaultExport, 'function')
 })
 
 test('named export', function (t) {
   t.plan(1)
-  t.assert.equal(typeof namedExport, 'function')
+  t.assert.strictEqual(typeof namedExport, 'function')
 })

--- a/test/export.js
+++ b/test/export.js
@@ -1,22 +1,22 @@
 'use strict'
 
-const t = require('tap')
+const test = require('node:test')
 
 const fastifyHttpProxy = require('..')
 const defaultExport = require('..').default
 const { fastifyHttpProxy: namedExport } = require('..')
 
-t.test('module export', function (t) {
+test('module export', function (t) {
   t.plan(1)
-  t.equal(typeof fastifyHttpProxy, 'function')
+  t.assert.equal(typeof fastifyHttpProxy, 'function')
 })
 
-t.test('default export', function (t) {
+test('default export', function (t) {
   t.plan(1)
-  t.equal(typeof defaultExport, 'function')
+  t.assert.equal(typeof defaultExport, 'function')
 })
 
-t.test('named export', function (t) {
+test('named export', function (t) {
   t.plan(1)
-  t.equal(typeof namedExport, 'function')
+  t.assert.equal(typeof namedExport, 'function')
 })

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -38,7 +38,7 @@ test('proxy socket.io', async (t) => {
 
   srvSocket.on('connection', (socket) => {
     socket.on('hello', (data) => {
-      t.assert.equal(data, 'world')
+      t.assert.strictEqual(data, 'world')
       socket.emit('hi', 'socket')
     })
   })
@@ -53,7 +53,7 @@ test('proxy socket.io', async (t) => {
   cliSocket.emit('hello', 'world')
 
   const [out] = await once(cliSocket, 'hi')
-  t.assert.equal(out, 'socket')
+  t.assert.strictEqual(out, 'socket')
 
   await Promise.all([once(cliSocket, 'disconnect'), srvProxy.close()])
 })

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const Fastify = require('fastify')
 const proxy = require('../')
 const ioServer = require('socket.io')
@@ -9,44 +9,51 @@ const { createServer } = require('node:http')
 const { promisify } = require('node:util')
 const { once } = require('node:events')
 
-test('proxy socket.io', async t => {
+test('proxy socket.io', async (t) => {
   t.plan(2)
 
   const srvUpstream = createServer()
-  t.teardown(srvUpstream.close.bind(srvUpstream))
+  t.after(() => {
+    srvUpstream.close()
+  })
 
   const srvSocket = new ioServer.Server(srvUpstream)
-  t.teardown(srvSocket.close.bind(srvSocket))
+  t.after(() => {
+    srvSocket.close()
+  })
 
   await promisify(srvUpstream.listen.bind(srvUpstream))(0)
 
   const srvProxy = Fastify()
-  t.teardown(srvProxy.close.bind(srvProxy))
+  t.after(() => {
+    srvProxy.close()
+  })
 
   srvProxy.register(proxy, {
     upstream: `http://127.0.0.1:${srvUpstream.address().port}`,
-    websocket: true
+    websocket: true,
   })
 
   await srvProxy.listen({ port: 0, host: '127.0.0.1' })
 
-  srvSocket.on('connection', socket => {
-    socket.on('hello', data => {
-      t.equal(data, 'world')
+  srvSocket.on('connection', (socket) => {
+    socket.on('hello', (data) => {
+      t.assert.equal(data, 'world')
       socket.emit('hi', 'socket')
     })
   })
 
-  const cliSocket = ioClient(`http://127.0.0.1:${srvProxy.server.address().port}`)
-  t.teardown(cliSocket.close.bind(cliSocket))
+  const cliSocket = ioClient(
+    `http://127.0.0.1:${srvProxy.server.address().port}`
+  )
+  t.after(() => {
+    cliSocket.close()
+  })
 
   cliSocket.emit('hello', 'world')
 
-  const out = await once(cliSocket, 'hi')
-  t.equal(out[0], 'socket')
+  const [out] = await once(cliSocket, 'hi')
+  t.assert.equal(out, 'socket')
 
-  await Promise.all([
-    once(cliSocket, 'disconnect'),
-    srvProxy.close()
-  ])
+  await Promise.all([once(cliSocket, 'disconnect'), srvProxy.close()])
 })

--- a/test/test.js
+++ b/test/test.js
@@ -68,12 +68,12 @@ async function run () {
     const resultRoot = await got(
       `http://localhost:${server.server.address().port}`
     )
-    t.assert.equal(resultRoot.body, 'this is root')
+    t.assert.strictEqual(resultRoot.body, 'this is root')
 
     const resultA = await got(
       `http://localhost:${server.server.address().port}/a`
     )
-    t.assert.equal(resultA.body, 'this is a')
+    t.assert.strictEqual(resultA.body, 'this is a')
   })
 
   test('dynamic upstream for basic proxy', async t => {
@@ -96,12 +96,12 @@ async function run () {
     const resultRoot = await got(
       `http://localhost:${server.server.address().port}`
     )
-    t.assert.equal(resultRoot.body, 'this is root')
+    t.assert.strictEqual(resultRoot.body, 'this is root')
 
     const resultA = await got(
       `http://localhost:${server.server.address().port}/a`
     )
-    t.assert.equal(resultA.body, 'this is a')
+    t.assert.strictEqual(resultA.body, 'this is a')
   })
 
   test('redirects passthrough', async t => {
@@ -121,8 +121,8 @@ async function run () {
         followRedirect: false
       }
     )
-    t.assert.equal(location, 'https://fastify.dev')
-    t.assert.equal(statusCode, 302)
+    t.assert.strictEqual(location, 'https://fastify.dev')
+    t.assert.strictEqual(statusCode, 302)
   })
 
   test('dynamic upstream for redirects passthrough', async t => {
@@ -147,8 +147,8 @@ async function run () {
         followRedirect: false
       }
     )
-    t.assert.equal(location, 'https://fastify.dev')
-    t.assert.equal(statusCode, 302)
+    t.assert.strictEqual(location, 'https://fastify.dev')
+    t.assert.strictEqual(statusCode, 302)
   })
 
   test('no upstream will throw', async t => {
@@ -157,7 +157,7 @@ async function run () {
     try {
       await server.ready()
     } catch (err) {
-      t.assert.equal(err.message, 'upstream must be specified')
+      t.assert.strictEqual(err.message, 'upstream must be specified')
       return
     }
     t.assert.fail()
@@ -176,17 +176,17 @@ async function run () {
     const resultRoot = await got(
       `http://localhost:${server.server.address().port}/my-prefix/`
     )
-    t.assert.equal(resultRoot.body, 'this is root')
+    t.assert.strictEqual(resultRoot.body, 'this is root')
 
     const withoutSlash = await got(
       `http://localhost:${server.server.address().port}/my-prefix`
     )
-    t.assert.equal(withoutSlash.body, 'this is root')
+    t.assert.strictEqual(withoutSlash.body, 'this is root')
 
     const resultA = await got(
       `http://localhost:${server.server.address().port}/my-prefix/a`
     )
-    t.assert.equal(resultA.body, 'this is a')
+    t.assert.strictEqual(resultA.body, 'this is a')
   })
 
   test('dynamic upstream for prefixed proxy', async t => {
@@ -207,17 +207,17 @@ async function run () {
     const resultRoot = await got(
       `http://localhost:${server.server.address().port}/my-prefix/`
     )
-    t.assert.equal(resultRoot.body, 'this is root')
+    t.assert.strictEqual(resultRoot.body, 'this is root')
 
     const withoutSlash = await got(
       `http://localhost:${server.server.address().port}/my-prefix`
     )
-    t.assert.equal(withoutSlash.body, 'this is root')
+    t.assert.strictEqual(withoutSlash.body, 'this is root')
 
     const resultA = await got(
       `http://localhost:${server.server.address().port}/my-prefix/a`
     )
-    t.assert.equal(resultA.body, 'this is a')
+    t.assert.strictEqual(resultA.body, 'this is a')
   })
 
   test('posting stuff', async t => {
@@ -264,7 +264,7 @@ async function run () {
       }
       )
     } catch (err) {
-      t.assert.equal(err.response.statusCode, 400)
+      t.assert.strictEqual(err.response.statusCode, 400)
       t.assert.deepStrictEqual(err.response.body, { message: 'invalid body.hello value' })
       return
     }
@@ -361,7 +361,7 @@ async function run () {
     try {
       await got(`http://localhost:${server.server.address().port}`)
     } catch (err) {
-      t.assert.equal(err.response.statusCode, 401)
+      t.assert.strictEqual(err.response.statusCode, 401)
       errored = true
     }
     t.assert.ok(errored)
@@ -370,7 +370,7 @@ async function run () {
     try {
       await got(`http://localhost:${server.server.address().port}/a`)
     } catch (err) {
-      t.assert.equal(err.response.statusCode, 401)
+      t.assert.strictEqual(err.response.statusCode, 401)
       errored = true
     }
     t.assert.ok(errored)
@@ -406,7 +406,7 @@ async function run () {
     try {
       await got(`http://localhost:${server.server.address().port}`)
     } catch (err) {
-      t.assert.equal(err.response.statusCode, 401)
+      t.assert.strictEqual(err.response.statusCode, 401)
       errored = true
     }
     t.assert.ok(errored)
@@ -445,12 +445,12 @@ async function run () {
     const firstProxyPrefix = await got(
       `http://localhost:${proxyServer.server.address().port}/api`
     )
-    t.assert.equal(firstProxyPrefix.body, 'this is root')
+    t.assert.strictEqual(firstProxyPrefix.body, 'this is root')
 
     const secondProxyPrefix = await got(
       `http://localhost:${proxyServer.server.address().port}/api2`
     )
-    t.assert.equal(secondProxyPrefix.body, 'this is root for origin2')
+    t.assert.strictEqual(secondProxyPrefix.body, 'this is root for origin2')
   })
 
   test('passes replyOptions object to reply.from() calls', async t => {
@@ -504,7 +504,7 @@ async function run () {
     const firstProxyPrefix = await got(
       `http://localhost:${proxyServer.server.address().port}/api/a`
     )
-    t.assert.equal(firstProxyPrefix.body, 'this is /api2/a')
+    t.assert.strictEqual(firstProxyPrefix.body, 'this is /api2/a')
   })
 
   test('rewritePrefix without prefix', async t => {
@@ -524,7 +524,7 @@ async function run () {
     const firstProxyPrefix = await got(
       `http://localhost:${proxyServer.server.address().port}/a`
     )
-    t.assert.equal(firstProxyPrefix.body, 'this is /api2/a')
+    t.assert.strictEqual(firstProxyPrefix.body, 'this is /api2/a')
   })
 
   test('prefix with variables', async t => {
@@ -545,7 +545,7 @@ async function run () {
     const firstProxyPrefix = await got(
       `http://localhost:${proxyServer.server.address().port}/api/123/static/a`
     )
-    t.assert.equal(firstProxyPrefix.body, 'this is /api2/a')
+    t.assert.strictEqual(firstProxyPrefix.body, 'this is /api2/a')
   })
 
   test('prefix and rewritePrefix with variables', async t => {
@@ -566,7 +566,7 @@ async function run () {
     const firstProxyPrefix = await got(
       `http://localhost:${proxyServer.server.address().port}/api/123/endpoint`
     )
-    t.assert.equal(firstProxyPrefix.body, 'this is "variable-api" endpoint with id 123')
+    t.assert.strictEqual(firstProxyPrefix.body, 'this is "variable-api" endpoint with id 123')
   })
 
   test('prefix (complete path) and rewritePrefix with variables and similar path', async t => {
@@ -587,7 +587,7 @@ async function run () {
     const firstProxyPrefix = await got(
       `http://localhost:${proxyServer.server.address().port}/api/123/static`
     )
-    t.assert.equal(firstProxyPrefix.body, 'this is "variable-api" endpoint with id 123')
+    t.assert.strictEqual(firstProxyPrefix.body, 'this is "variable-api" endpoint with id 123')
   })
 
   test('prefix and rewritePrefix with variables with different paths', async t => {
@@ -608,7 +608,7 @@ async function run () {
     const firstProxyPrefix = await got(
       `http://localhost:${proxyServer.server.address().port}/123`
     )
-    t.assert.equal(firstProxyPrefix.body, 'this is "variable-api" endpoint with id 123')
+    t.assert.strictEqual(firstProxyPrefix.body, 'this is "variable-api" endpoint with id 123')
   })
 
   test('rewrite location headers', async t => {
@@ -634,7 +634,7 @@ async function run () {
         json: { hello: 'world' }
       }
     )
-    t.assert.equal(location, '/api/something')
+    t.assert.strictEqual(location, '/api/something')
   })
 
   test('location headers is preserved when internalRewriteLocationHeader option is false', async t => {
@@ -660,7 +660,7 @@ async function run () {
         method: 'POST'
       }
     )
-    t.assert.equal(location, '/relative-url')
+    t.assert.strictEqual(location, '/relative-url')
   })
 
   test('passes onResponse option to reply.from() calls', async t => {
@@ -721,7 +721,7 @@ async function run () {
         json: { hello: 'world' }
       }
     )
-    t.assert.equal(location, '/something')
+    t.assert.strictEqual(location, '/something')
   })
 
   test('proxy request timeout', async t => {
@@ -744,8 +744,8 @@ async function run () {
         { retry: 0 }
       )
     } catch (err) {
-      t.assert.equal(err.response.statusCode, 504)
-      t.assert.equal(err.response.statusMessage, 'Gateway Timeout')
+      t.assert.strictEqual(err.response.statusCode, 504)
+      t.assert.strictEqual(err.response.statusMessage, 'Gateway Timeout')
       return
     }
     t.assert.fail()
@@ -775,7 +775,7 @@ async function run () {
     try {
       await await got(`http://localhost:${server.server.address().port}/a`)
     } catch (err) {
-      t.assert.equal(err.response.statusCode, 404)
+      t.assert.strictEqual(err.response.statusCode, 404)
       errored = true
     }
     t.assert.ok(errored)
@@ -825,14 +825,14 @@ async function run () {
       })
       t.assert.fail()
     } catch (err) {
-      t.assert.equal(err.response.statusCode, 404)
+      t.assert.strictEqual(err.response.statusCode, 404)
     }
 
     try {
       await got(`http://localhost:${server.server.address().port}/a`)
       t.assert.fail()
     } catch (err) {
-      t.assert.equal(err.response.statusCode, 404)
+      t.assert.strictEqual(err.response.statusCode, 404)
     }
   })
 
@@ -858,14 +858,14 @@ async function run () {
         'test-header': 'with-proxy'
       }
     })
-    t.assert.equal(resultProxied.body, 'this is a')
+    t.assert.strictEqual(resultProxied.body, 'this is a')
 
     const resultUnproxied = await got(`http://localhost:${server.server.address().port}/a`, {
       headers: {
         'test-header': 'without-proxy'
       }
     })
-    t.assert.equal(resultUnproxied.body, 'this is unproxied a')
+    t.assert.strictEqual(resultUnproxied.body, 'this is unproxied a')
   })
 
   test('prefixed proxy with query search', async t => {
@@ -892,12 +892,12 @@ async function run () {
     const resultRoot = await got(
       `${proxyAddress}/second-service?lang=en`
     )
-    t.assert.equal(resultRoot.body, 'Hello World - lang = en')
+    t.assert.strictEqual(resultRoot.body, 'Hello World - lang = en')
 
     const resultFooRoute = await got(
       `${proxyAddress}/second-service/foo?lang=en`
     )
-    t.assert.equal(resultFooRoute.body, 'Hello World (foo) - lang = en')
+    t.assert.strictEqual(resultFooRoute.body, 'Hello World (foo) - lang = en')
   })
 
   test('keep the query params on proxy', { only: true }, async t => {
@@ -919,7 +919,7 @@ async function run () {
       `http://localhost:${proxyServer.server.address().port}/api/123/endpoint?foo=bar&foo=baz&abc=qux`
     )
     const queryParams = JSON.stringify(qs.parse('foo=bar&foo=baz&abc=qux'))
-    t.assert.equal(firstProxyPrefix.body, `this is "variable-api" endpoint with id 123 and query params ${queryParams}`)
+    t.assert.strictEqual(firstProxyPrefix.body, `this is "variable-api" endpoint with id 123 and query params ${queryParams}`)
   })
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { teardown, test } = require('tap')
+const { after, test } = require('node:test')
 const Fastify = require('fastify')
 const proxy = require('../')
 const got = require('got')
@@ -54,7 +54,7 @@ async function run () {
 
   await origin.listen({ port: 0 })
 
-  teardown(() => origin.close())
+  after(() => origin.close())
 
   test('basic proxy', async t => {
     const server = Fastify()
@@ -63,17 +63,17 @@ async function run () {
     })
 
     await server.listen({ port: 0 })
-    t.teardown(server.close.bind(server))
+    t.after(() => server.close())
 
     const resultRoot = await got(
       `http://localhost:${server.server.address().port}`
     )
-    t.equal(resultRoot.body, 'this is root')
+    t.assert.equal(resultRoot.body, 'this is root')
 
     const resultA = await got(
       `http://localhost:${server.server.address().port}/a`
     )
-    t.equal(resultA.body, 'this is a')
+    t.assert.equal(resultA.body, 'this is a')
   })
 
   test('dynamic upstream for basic proxy', async t => {
@@ -91,17 +91,17 @@ async function run () {
     })
 
     await server.listen({ port: 0 })
-    t.teardown(server.close.bind(server))
+    t.after(() => server.close())
 
     const resultRoot = await got(
       `http://localhost:${server.server.address().port}`
     )
-    t.equal(resultRoot.body, 'this is root')
+    t.assert.equal(resultRoot.body, 'this is root')
 
     const resultA = await got(
       `http://localhost:${server.server.address().port}/a`
     )
-    t.equal(resultA.body, 'this is a')
+    t.assert.equal(resultA.body, 'this is a')
   })
 
   test('redirects passthrough', async t => {
@@ -111,7 +111,7 @@ async function run () {
     })
 
     await server.listen({ port: 0 })
-    t.teardown(server.close.bind(server))
+    t.after(() => server.close())
 
     const {
       headers: { location },
@@ -121,8 +121,8 @@ async function run () {
         followRedirect: false
       }
     )
-    t.equal(location, 'https://fastify.dev')
-    t.equal(statusCode, 302)
+    t.assert.equal(location, 'https://fastify.dev')
+    t.assert.equal(statusCode, 302)
   })
 
   test('dynamic upstream for redirects passthrough', async t => {
@@ -137,7 +137,7 @@ async function run () {
     })
 
     await server.listen({ port: 0 })
-    t.teardown(server.close.bind(server))
+    t.after(() => server.close())
 
     const {
       headers: { location },
@@ -147,8 +147,8 @@ async function run () {
         followRedirect: false
       }
     )
-    t.equal(location, 'https://fastify.dev')
-    t.equal(statusCode, 302)
+    t.assert.equal(location, 'https://fastify.dev')
+    t.assert.equal(statusCode, 302)
   })
 
   test('no upstream will throw', async t => {
@@ -157,10 +157,10 @@ async function run () {
     try {
       await server.ready()
     } catch (err) {
-      t.equal(err.message, 'upstream must be specified')
+      t.assert.equal(err.message, 'upstream must be specified')
       return
     }
-    t.fail()
+    t.assert.fail()
   })
 
   test('prefixed proxy', async t => {
@@ -171,22 +171,22 @@ async function run () {
     })
 
     await server.listen({ port: 0 })
-    t.teardown(server.close.bind(server))
+    t.after(() => server.close())
 
     const resultRoot = await got(
       `http://localhost:${server.server.address().port}/my-prefix/`
     )
-    t.equal(resultRoot.body, 'this is root')
+    t.assert.equal(resultRoot.body, 'this is root')
 
     const withoutSlash = await got(
       `http://localhost:${server.server.address().port}/my-prefix`
     )
-    t.equal(withoutSlash.body, 'this is root')
+    t.assert.equal(withoutSlash.body, 'this is root')
 
     const resultA = await got(
       `http://localhost:${server.server.address().port}/my-prefix/a`
     )
-    t.equal(resultA.body, 'this is a')
+    t.assert.equal(resultA.body, 'this is a')
   })
 
   test('dynamic upstream for prefixed proxy', async t => {
@@ -202,22 +202,22 @@ async function run () {
     })
 
     await server.listen({ port: 0 })
-    t.teardown(server.close.bind(server))
+    t.after(() => server.close())
 
     const resultRoot = await got(
       `http://localhost:${server.server.address().port}/my-prefix/`
     )
-    t.equal(resultRoot.body, 'this is root')
+    t.assert.equal(resultRoot.body, 'this is root')
 
     const withoutSlash = await got(
       `http://localhost:${server.server.address().port}/my-prefix`
     )
-    t.equal(withoutSlash.body, 'this is root')
+    t.assert.equal(withoutSlash.body, 'this is root')
 
     const resultA = await got(
       `http://localhost:${server.server.address().port}/my-prefix/a`
     )
-    t.equal(resultA.body, 'this is a')
+    t.assert.equal(resultA.body, 'this is a')
   })
 
   test('posting stuff', async t => {
@@ -227,7 +227,7 @@ async function run () {
     })
 
     await server.listen({ port: 0 })
-    t.teardown(server.close.bind(server))
+    t.after(() => server.close())
 
     const resultRoot = await got(
       `http://localhost:${server.server.address().port}/this-has-data`,
@@ -237,7 +237,7 @@ async function run () {
         responseType: 'json'
       }
     )
-    t.same(resultRoot.body, { something: 'posted' })
+    t.assert.deepStrictEqual(resultRoot.body, { something: 'posted' })
   })
 
   test('preValidation post payload contains invalid data', async t => {
@@ -252,7 +252,7 @@ async function run () {
     })
 
     await server.listen({ port: 0 })
-    t.teardown(server.close.bind(server))
+    t.after(() => server.close())
 
     try {
       await got(
@@ -264,11 +264,11 @@ async function run () {
       }
       )
     } catch (err) {
-      t.equal(err.response.statusCode, 400)
-      t.same(err.response.body, { message: 'invalid body.hello value' })
+      t.assert.equal(err.response.statusCode, 400)
+      t.assert.deepStrictEqual(err.response.body, { message: 'invalid body.hello value' })
       return
     }
-    t.fail()
+    t.assert.fail()
   })
 
   test('preValidation post payload contains valid data', async t => {
@@ -283,7 +283,7 @@ async function run () {
     })
 
     await server.listen({ port: 0 })
-    t.teardown(server.close.bind(server))
+    t.after(() => server.close())
 
     const resultRoot = await got(
       `http://localhost:${server.server.address().port}/this-has-data`,
@@ -293,7 +293,7 @@ async function run () {
         responseType: 'json'
       }
     )
-    t.same(resultRoot.body, { something: 'posted' })
+    t.assert.deepStrictEqual(resultRoot.body, { something: 'posted' })
   })
 
   test('dynamic upstream for posting stuff', async t => {
@@ -308,7 +308,7 @@ async function run () {
     })
 
     await server.listen({ port: 0 })
-    t.teardown(server.close.bind(server))
+    t.after(() => server.close())
 
     const resultRoot = await got(
       `http://localhost:${server.server.address().port}/this-has-data`,
@@ -318,7 +318,7 @@ async function run () {
         responseType: 'json'
       }
     )
-    t.same(resultRoot.body, { something: 'posted' })
+    t.assert.deepStrictEqual(resultRoot.body, { something: 'posted' })
   })
 
   test('skip proxying the incoming payload', async t => {
@@ -327,13 +327,13 @@ async function run () {
       upstream: `http://localhost:${origin.server.address().port}`,
       proxyPayloads: false,
       preHandler (request, _reply, next) {
-        t.same(request.body, { hello: 'world' })
+        t.assert.deepStrictEqual(request.body, { hello: 'world' })
         next()
       }
     })
 
     await server.listen({ port: 0 })
-    t.teardown(server.close.bind(server))
+    t.after(() => server.close())
 
     await got(
       `http://localhost:${server.server.address().port}/this-has-data`,
@@ -355,25 +355,25 @@ async function run () {
     })
 
     await server.listen({ port: 0 })
-    t.teardown(server.close.bind(server))
+    t.after(() => server.close())
 
     let errored = false
     try {
       await got(`http://localhost:${server.server.address().port}`)
     } catch (err) {
-      t.equal(err.response.statusCode, 401)
+      t.assert.equal(err.response.statusCode, 401)
       errored = true
     }
-    t.ok(errored)
+    t.assert.ok(errored)
 
     errored = false
     try {
       await got(`http://localhost:${server.server.address().port}/a`)
     } catch (err) {
-      t.equal(err.response.statusCode, 401)
+      t.assert.equal(err.response.statusCode, 401)
       errored = true
     }
-    t.ok(errored)
+    t.assert.ok(errored)
   })
 
   test('preHandler gets config', async t => {
@@ -382,7 +382,7 @@ async function run () {
       upstream: `http://localhost:${origin.server.address().port}`,
       config: { foo: 'bar' },
       async preHandler (request) {
-        t.same(request.routeOptions.config, {
+        t.assert.deepStrictEqual(request.routeOptions.config, {
           foo: 'bar',
           url: '/',
           method: [
@@ -400,16 +400,16 @@ async function run () {
     })
 
     await server.listen({ port: 0 })
-    t.teardown(server.close.bind(server))
+    t.after(() => server.close())
 
     let errored = false
     try {
       await got(`http://localhost:${server.server.address().port}`)
     } catch (err) {
-      t.equal(err.response.statusCode, 401)
+      t.assert.equal(err.response.statusCode, 401)
       errored = true
     }
-    t.ok(errored)
+    t.assert.ok(errored)
   })
 
   test('multiple prefixes with multiple plugins', async t => {
@@ -437,7 +437,7 @@ async function run () {
 
     await proxyServer.listen({ port: 0 })
 
-    t.teardown(() => {
+    t.after(() => {
       origin2.close()
       proxyServer.close()
     })
@@ -445,12 +445,12 @@ async function run () {
     const firstProxyPrefix = await got(
       `http://localhost:${proxyServer.server.address().port}/api`
     )
-    t.equal(firstProxyPrefix.body, 'this is root')
+    t.assert.equal(firstProxyPrefix.body, 'this is root')
 
     const secondProxyPrefix = await got(
       `http://localhost:${proxyServer.server.address().port}/api2`
     )
-    t.equal(secondProxyPrefix.body, 'this is root for origin2')
+    t.assert.equal(secondProxyPrefix.body, 'this is root for origin2')
   })
 
   test('passes replyOptions object to reply.from() calls', async t => {
@@ -469,7 +469,7 @@ async function run () {
 
     await proxyServer.listen({ port: 0 })
 
-    t.teardown(() => {
+    t.after(() => {
       proxyServer.close()
     })
 
@@ -479,7 +479,11 @@ async function run () {
         'x-req': 'from-header'
       }
     })
-    t.match(headers, { 'x-test': 'test', 'x-req': 'from-header' })
+    const expected = { 'x-test': 'test', 'x-req': 'from-header' }
+
+    for (const [key, value] of Object.entries(expected)) {
+      t.assert.strictEqual(headers[key], value, `Header ${key} does not match`)
+    }
   })
 
   test('rewritePrefix', async t => {
@@ -493,14 +497,14 @@ async function run () {
 
     await proxyServer.listen({ port: 0 })
 
-    t.teardown(() => {
+    t.after(() => {
       proxyServer.close()
     })
 
     const firstProxyPrefix = await got(
       `http://localhost:${proxyServer.server.address().port}/api/a`
     )
-    t.equal(firstProxyPrefix.body, 'this is /api2/a')
+    t.assert.equal(firstProxyPrefix.body, 'this is /api2/a')
   })
 
   test('rewritePrefix without prefix', async t => {
@@ -513,14 +517,14 @@ async function run () {
 
     await proxyServer.listen({ port: 0 })
 
-    t.teardown(() => {
+    t.after(() => {
       proxyServer.close()
     })
 
     const firstProxyPrefix = await got(
       `http://localhost:${proxyServer.server.address().port}/a`
     )
-    t.equal(firstProxyPrefix.body, 'this is /api2/a')
+    t.assert.equal(firstProxyPrefix.body, 'this is /api2/a')
   })
 
   test('prefix with variables', async t => {
@@ -534,14 +538,14 @@ async function run () {
 
     await proxyServer.listen({ port: 0 })
 
-    t.teardown(() => {
+    t.after(() => {
       proxyServer.close()
     })
 
     const firstProxyPrefix = await got(
       `http://localhost:${proxyServer.server.address().port}/api/123/static/a`
     )
-    t.equal(firstProxyPrefix.body, 'this is /api2/a')
+    t.assert.equal(firstProxyPrefix.body, 'this is /api2/a')
   })
 
   test('prefix and rewritePrefix with variables', async t => {
@@ -555,14 +559,14 @@ async function run () {
 
     await proxyServer.listen({ port: 0 })
 
-    t.teardown(() => {
+    t.after(() => {
       proxyServer.close()
     })
 
     const firstProxyPrefix = await got(
       `http://localhost:${proxyServer.server.address().port}/api/123/endpoint`
     )
-    t.equal(firstProxyPrefix.body, 'this is "variable-api" endpoint with id 123')
+    t.assert.equal(firstProxyPrefix.body, 'this is "variable-api" endpoint with id 123')
   })
 
   test('prefix (complete path) and rewritePrefix with variables and similar path', async t => {
@@ -576,14 +580,14 @@ async function run () {
 
     await proxyServer.listen({ port: 0 })
 
-    t.teardown(() => {
+    t.after(() => {
       proxyServer.close()
     })
 
     const firstProxyPrefix = await got(
       `http://localhost:${proxyServer.server.address().port}/api/123/static`
     )
-    t.equal(firstProxyPrefix.body, 'this is "variable-api" endpoint with id 123')
+    t.assert.equal(firstProxyPrefix.body, 'this is "variable-api" endpoint with id 123')
   })
 
   test('prefix and rewritePrefix with variables with different paths', async t => {
@@ -597,14 +601,14 @@ async function run () {
 
     await proxyServer.listen({ port: 0 })
 
-    t.teardown(() => {
+    t.after(() => {
       proxyServer.close()
     })
 
     const firstProxyPrefix = await got(
       `http://localhost:${proxyServer.server.address().port}/123`
     )
-    t.equal(firstProxyPrefix.body, 'this is "variable-api" endpoint with id 123')
+    t.assert.equal(firstProxyPrefix.body, 'this is "variable-api" endpoint with id 123')
   })
 
   test('rewrite location headers', async t => {
@@ -617,7 +621,7 @@ async function run () {
 
     await proxyServer.listen({ port: 0 })
 
-    t.teardown(() => {
+    t.after(() => {
       proxyServer.close()
     })
 
@@ -630,7 +634,7 @@ async function run () {
         json: { hello: 'world' }
       }
     )
-    t.equal(location, '/api/something')
+    t.assert.equal(location, '/api/something')
   })
 
   test('location headers is preserved when internalRewriteLocationHeader option is false', async t => {
@@ -644,7 +648,7 @@ async function run () {
 
     await proxyServer.listen({ port: 0 })
 
-    t.teardown(() => {
+    t.after(() => {
       proxyServer.close()
     })
 
@@ -656,7 +660,7 @@ async function run () {
         method: 'POST'
       }
     )
-    t.equal(location, '/relative-url')
+    t.assert.equal(location, '/relative-url')
   })
 
   test('passes onResponse option to reply.from() calls', async t => {
@@ -683,7 +687,7 @@ async function run () {
 
     await proxyServer.listen({ port: 0 })
 
-    t.teardown(() => {
+    t.after(() => {
       proxyServer.close()
     })
 
@@ -691,7 +695,7 @@ async function run () {
       `http://localhost:${proxyServer.server.address().port}/api`
     )
 
-    t.match(body, 'THIS IS ROOT')
+    t.assert.match(body, /THIS IS ROOT/)
   })
 
   test('undici POST', async t => {
@@ -704,7 +708,7 @@ async function run () {
 
     await proxyServer.listen({ port: 0 })
 
-    t.teardown(() => {
+    t.after(() => {
       proxyServer.close()
     })
 
@@ -717,7 +721,7 @@ async function run () {
         json: { hello: 'world' }
       }
     )
-    t.equal(location, '/something')
+    t.assert.equal(location, '/something')
   })
 
   test('proxy request timeout', async t => {
@@ -732,7 +736,7 @@ async function run () {
     })
 
     await server.listen({ port: 0 })
-    t.teardown(server.close.bind(server))
+    t.after(() => server.close())
 
     try {
       await got(
@@ -740,11 +744,11 @@ async function run () {
         { retry: 0 }
       )
     } catch (err) {
-      t.equal(err.response.statusCode, 504)
-      t.equal(err.response.statusMessage, 'Gateway Timeout')
+      t.assert.equal(err.response.statusCode, 504)
+      t.assert.equal(err.response.statusMessage, 'Gateway Timeout')
       return
     }
-    t.fail()
+    t.assert.fail()
   })
 
   test('settings of method types', async t => {
@@ -755,7 +759,7 @@ async function run () {
     })
 
     await server.listen({ port: 0 })
-    t.teardown(server.close.bind(server))
+    t.after(() => server.close())
 
     const resultRoot = await got(
       `http://localhost:${server.server.address().port}/this-has-data`,
@@ -765,16 +769,16 @@ async function run () {
         responseType: 'json'
       }
     )
-    t.same(resultRoot.body, { something: 'posted' })
+    t.assert.deepStrictEqual(resultRoot.body, { something: 'posted' })
 
     let errored = false
     try {
       await await got(`http://localhost:${server.server.address().port}/a`)
     } catch (err) {
-      t.equal(err.response.statusCode, 404)
+      t.assert.equal(err.response.statusCode, 404)
       errored = true
     }
-    t.ok(errored)
+    t.assert.ok(errored)
   })
 
   const getTestConstraint = () => ({
@@ -806,7 +810,7 @@ async function run () {
     })
 
     await server.listen({ port: 0 })
-    t.teardown(server.close.bind(server))
+    t.after(() => server.close())
     await got(`http://localhost:${server.server.address().port}/a`, {
       headers: {
         'test-header': 'valid-value'
@@ -819,16 +823,16 @@ async function run () {
           'test-header': 'invalid-value'
         }
       })
-      t.fail()
+      t.assert.fail()
     } catch (err) {
-      t.equal(err.response.statusCode, 404)
+      t.assert.equal(err.response.statusCode, 404)
     }
 
     try {
       await got(`http://localhost:${server.server.address().port}/a`)
-      t.fail()
+      t.assert.fail()
     } catch (err) {
-      t.equal(err.response.statusCode, 404)
+      t.assert.equal(err.response.statusCode, 404)
     }
   })
 
@@ -847,21 +851,21 @@ async function run () {
     })
 
     await server.listen({ port: 0 })
-    t.teardown(server.close.bind(server))
+    t.after(() => server.close())
 
     const resultProxied = await got(`http://localhost:${server.server.address().port}/a`, {
       headers: {
         'test-header': 'with-proxy'
       }
     })
-    t.equal(resultProxied.body, 'this is a')
+    t.assert.equal(resultProxied.body, 'this is a')
 
     const resultUnproxied = await got(`http://localhost:${server.server.address().port}/a`, {
       headers: {
         'test-header': 'without-proxy'
       }
     })
-    t.equal(resultUnproxied.body, 'this is unproxied a')
+    t.assert.equal(resultUnproxied.body, 'this is unproxied a')
   })
 
   test('prefixed proxy with query search', async t => {
@@ -882,18 +886,18 @@ async function run () {
     })
     const proxyAddress = await proxyServer.listen({ port: 0 })
 
-    t.teardown(proxyServer.close.bind(proxyServer))
-    t.teardown(appServer.close.bind(appServer))
+    t.after(() => { proxyServer.close() })
+    t.after(() => { appServer.close() })
 
     const resultRoot = await got(
       `${proxyAddress}/second-service?lang=en`
     )
-    t.equal(resultRoot.body, 'Hello World - lang = en')
+    t.assert.equal(resultRoot.body, 'Hello World - lang = en')
 
     const resultFooRoute = await got(
       `${proxyAddress}/second-service/foo?lang=en`
     )
-    t.equal(resultFooRoute.body, 'Hello World (foo) - lang = en')
+    t.assert.equal(resultFooRoute.body, 'Hello World (foo) - lang = en')
   })
 
   test('keep the query params on proxy', { only: true }, async t => {
@@ -907,7 +911,7 @@ async function run () {
 
     await proxyServer.listen({ port: 0 })
 
-    t.teardown(() => {
+    t.after(() => {
       proxyServer.close()
     })
 
@@ -915,7 +919,7 @@ async function run () {
       `http://localhost:${proxyServer.server.address().port}/api/123/endpoint?foo=bar&foo=baz&abc=qux`
     )
     const queryParams = JSON.stringify(qs.parse('foo=bar&foo=baz&abc=qux'))
-    t.equal(firstProxyPrefix.body, `this is "variable-api" endpoint with id 123 and query params ${queryParams}`)
+    t.assert.equal(firstProxyPrefix.body, `this is "variable-api" endpoint with id 123 and query params ${queryParams}`)
   })
 }
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -15,6 +15,6 @@ test('convertUrlToWebSocket', function (t) {
   ]
   t.plan(testData.length)
   for (const { input, expected } of testData) {
-    t.assert.equal(convertUrlToWebSocket(input), expected)
+    t.assert.strictEqual(convertUrlToWebSocket(input), expected)
   }
 })

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,9 +1,9 @@
 'use strict'
 
-const t = require('tap')
+const { test } = require('node:test')
 const { convertUrlToWebSocket } = require('../utils')
 
-t.test('convertUrlToWebSocket', function (t) {
+test('convertUrlToWebSocket', function (t) {
   const testData = [
     { input: 'http://localhost', expected: 'ws://localhost' },
     { input: 'https://localhost', expected: 'wss://localhost' },
@@ -15,6 +15,6 @@ t.test('convertUrlToWebSocket', function (t) {
   ]
   t.plan(testData.length)
   for (const { input, expected } of testData) {
-    t.equal(convertUrlToWebSocket(input), expected)
+    t.assert.equal(convertUrlToWebSocket(input), expected)
   }
 })

--- a/test/websocket-pathname.js
+++ b/test/websocket-pathname.js
@@ -1,4 +1,4 @@
-const { test } = require('tap')
+const { test } = require('node:test')
 const Fastify = require('fastify')
 const proxy = require('..')
 const WebSocket = require('ws')
@@ -13,8 +13,8 @@ test('keep proxy websocket pathname', async (t) => {
   const origin = createServer()
   const wss = new WebSocket.Server({ server: origin })
 
-  t.teardown(wss.close.bind(wss))
-  t.teardown(origin.close.bind(origin))
+  t.after(() => { wss.close() })
+  t.after(() => { origin.close() })
 
   const serverMessages = []
   wss.on('connection', (ws, request) => {
@@ -39,7 +39,7 @@ test('keep proxy websocket pathname', async (t) => {
   })
 
   await server.listen({ port: 0, host: '127.0.0.1' })
-  t.teardown(server.close.bind(server))
+  t.after(() => { server.close() })
 
   // Start websocket with different upstream for connect, added path.
   const ws = new WebSocket(`ws://${host}:${server.server.address().port}${path}`)
@@ -59,11 +59,11 @@ test('keep proxy websocket pathname', async (t) => {
 
     const [reply, binaryAnswer] = await once(ws, 'message')
 
-    t.equal(reply.toString(), msg)
-    t.equal(binaryAnswer, binary)
+    t.assert.equal(reply.toString(), msg)
+    t.assert.equal(binaryAnswer, binary)
   }
   // Also check "path", must be the same.
-  t.strictSame(serverMessages, [
+  t.assert.deepStrictEqual(serverMessages, [
     ['hello', false, host, path],
     ['fastify', true, host, path]
   ])

--- a/test/websocket-pathname.js
+++ b/test/websocket-pathname.js
@@ -59,8 +59,8 @@ test('keep proxy websocket pathname', async (t) => {
 
     const [reply, binaryAnswer] = await once(ws, 'message')
 
-    t.assert.equal(reply.toString(), msg)
-    t.assert.equal(binaryAnswer, binary)
+    t.assert.strictEqual(reply.toString(), msg)
+    t.assert.strictEqual(binaryAnswer, binary)
   }
   // Also check "path", must be the same.
   t.assert.deepStrictEqual(serverMessages, [

--- a/test/websocket-querystring.js
+++ b/test/websocket-querystring.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const Fastify = require('fastify')
 const proxy = require('../')
 const WebSocket = require('ws')
@@ -16,13 +16,13 @@ test('websocket proxy with object queryString', async (t) => {
 
   const origin = createServer()
   const wss = new WebSocket.Server({ server: origin })
-  t.teardown(wss.close.bind(wss))
-  t.teardown(origin.close.bind(origin))
+  t.after(() => { wss.close() })
+  t.after(() => { origin.close() })
 
   const serverMessages = []
   wss.on('connection', (ws, request) => {
-    t.equal(ws.protocol, subprotocolValue)
-    t.equal(request.url, '/?q=test')
+    t.assert.equal(ws.protocol, subprotocolValue)
+    t.assert.equal(request.url, '/?q=test')
     ws.on('message', (message, binary) => {
       serverMessages.push([message.toString(), binary])
       // echo
@@ -42,22 +42,22 @@ test('websocket proxy with object queryString', async (t) => {
   })
 
   await server.listen({ port: 0, host: '127.0.0.1' })
-  t.teardown(server.close.bind(server))
+  t.after(() => { server.close() })
 
   const ws = new WebSocket(`ws://127.0.0.1:${server.server.address().port}`, [subprotocolValue])
   await once(ws, 'open')
 
   ws.send('hello', { binary: false })
   const [reply0, binary0] = await once(ws, 'message')
-  t.equal(reply0.toString(), 'hello')
-  t.equal(binary0, false)
+  t.assert.equal(reply0.toString(), 'hello')
+  t.assert.equal(binary0, false)
 
   ws.send(Buffer.from('fastify'), { binary: true })
   const [reply1, binary1] = await once(ws, 'message')
-  t.equal(reply1.toString(), 'fastify')
-  t.equal(binary1, true)
+  t.assert.equal(reply1.toString(), 'fastify')
+  t.assert.equal(binary1, true)
 
-  t.strictSame(serverMessages, [
+  t.assert.deepStrictEqual(serverMessages, [
     ['hello', false],
     ['fastify', true]
   ])
@@ -73,13 +73,13 @@ test('websocket proxy with function queryString', async (t) => {
 
   const origin = createServer()
   const wss = new WebSocket.Server({ server: origin })
-  t.teardown(wss.close.bind(wss))
-  t.teardown(origin.close.bind(origin))
+  t.after(() => { wss.close() })
+  t.after(() => { origin.close() })
 
   const serverMessages = []
   wss.on('connection', (ws, request) => {
-    t.equal(ws.protocol, subprotocolValue)
-    t.equal(request.url, '/?q=test')
+    t.assert.equal(ws.protocol, subprotocolValue)
+    t.assert.equal(request.url, '/?q=test')
     ws.on('message', (message, binary) => {
       serverMessages.push([message.toString(), binary])
       // echo
@@ -99,22 +99,22 @@ test('websocket proxy with function queryString', async (t) => {
   })
 
   await server.listen({ port: 0, host: '127.0.0.1' })
-  t.teardown(server.close.bind(server))
+  t.after(() => { server.close() })
 
   const ws = new WebSocket(`ws://127.0.0.1:${server.server.address().port}`, [subprotocolValue])
   await once(ws, 'open')
 
   ws.send('hello', { binary: false })
   const [reply0, binary0] = await once(ws, 'message')
-  t.equal(reply0.toString(), 'hello')
-  t.equal(binary0, false)
+  t.assert.equal(reply0.toString(), 'hello')
+  t.assert.equal(binary0, false)
 
   ws.send(Buffer.from('fastify'), { binary: true })
   const [reply1, binary1] = await once(ws, 'message')
-  t.equal(reply1.toString(), 'fastify')
-  t.equal(binary1, true)
+  t.assert.equal(reply1.toString(), 'fastify')
+  t.assert.equal(binary1, true)
 
-  t.strictSame(serverMessages, [
+  t.assert.deepStrictEqual(serverMessages, [
     ['hello', false],
     ['fastify', true]
   ])

--- a/test/websocket-querystring.js
+++ b/test/websocket-querystring.js
@@ -21,8 +21,8 @@ test('websocket proxy with object queryString', async (t) => {
 
   const serverMessages = []
   wss.on('connection', (ws, request) => {
-    t.assert.equal(ws.protocol, subprotocolValue)
-    t.assert.equal(request.url, '/?q=test')
+    t.assert.strictEqual(ws.protocol, subprotocolValue)
+    t.assert.strictEqual(request.url, '/?q=test')
     ws.on('message', (message, binary) => {
       serverMessages.push([message.toString(), binary])
       // echo
@@ -49,13 +49,13 @@ test('websocket proxy with object queryString', async (t) => {
 
   ws.send('hello', { binary: false })
   const [reply0, binary0] = await once(ws, 'message')
-  t.assert.equal(reply0.toString(), 'hello')
-  t.assert.equal(binary0, false)
+  t.assert.strictEqual(reply0.toString(), 'hello')
+  t.assert.strictEqual(binary0, false)
 
   ws.send(Buffer.from('fastify'), { binary: true })
   const [reply1, binary1] = await once(ws, 'message')
-  t.assert.equal(reply1.toString(), 'fastify')
-  t.assert.equal(binary1, true)
+  t.assert.strictEqual(reply1.toString(), 'fastify')
+  t.assert.strictEqual(binary1, true)
 
   t.assert.deepStrictEqual(serverMessages, [
     ['hello', false],
@@ -78,8 +78,8 @@ test('websocket proxy with function queryString', async (t) => {
 
   const serverMessages = []
   wss.on('connection', (ws, request) => {
-    t.assert.equal(ws.protocol, subprotocolValue)
-    t.assert.equal(request.url, '/?q=test')
+    t.assert.strictEqual(ws.protocol, subprotocolValue)
+    t.assert.strictEqual(request.url, '/?q=test')
     ws.on('message', (message, binary) => {
       serverMessages.push([message.toString(), binary])
       // echo
@@ -106,13 +106,13 @@ test('websocket proxy with function queryString', async (t) => {
 
   ws.send('hello', { binary: false })
   const [reply0, binary0] = await once(ws, 'message')
-  t.assert.equal(reply0.toString(), 'hello')
-  t.assert.equal(binary0, false)
+  t.assert.strictEqual(reply0.toString(), 'hello')
+  t.assert.strictEqual(binary0, false)
 
   ws.send(Buffer.from('fastify'), { binary: true })
   const [reply1, binary1] = await once(ws, 'message')
-  t.assert.equal(reply1.toString(), 'fastify')
-  t.assert.equal(binary1, true)
+  t.assert.strictEqual(reply1.toString(), 'fastify')
+  t.assert.strictEqual(binary1, true)
 
   t.assert.deepStrictEqual(serverMessages, [
     ['hello', false],

--- a/test/websocket.js
+++ b/test/websocket.js
@@ -20,8 +20,8 @@ test('basic websocket proxy', async (t) => {
 
   const serverMessages = []
   wss.on('connection', (ws, request) => {
-    t.assert.equal(ws.protocol, subprotocolValue)
-    t.assert.equal(request.headers.cookie, cookieValue)
+    t.assert.strictEqual(ws.protocol, subprotocolValue)
+    t.assert.strictEqual(request.headers.cookie, cookieValue)
     ws.on('message', (message, binary) => {
       serverMessages.push([message.toString(), binary])
       // echo
@@ -45,13 +45,13 @@ test('basic websocket proxy', async (t) => {
 
   ws.send('hello', { binary: false })
   const [reply0, binary0] = await once(ws, 'message')
-  t.assert.equal(reply0.toString(), 'hello')
-  t.assert.equal(binary0, false)
+  t.assert.strictEqual(reply0.toString(), 'hello')
+  t.assert.strictEqual(binary0, false)
 
   ws.send(Buffer.from('fastify'), { binary: true })
   const [reply1, binary1] = await once(ws, 'message')
-  t.assert.equal(reply1.toString(), 'fastify')
-  t.assert.equal(binary1, true)
+  t.assert.strictEqual(reply1.toString(), 'fastify')
+  t.assert.strictEqual(binary1, true)
 
   t.assert.deepStrictEqual(serverMessages, [
     ['hello', false],
@@ -77,7 +77,7 @@ test('multiple websocket upstreams', async (t) => {
 
     wss.once('connection', (ws) => {
       ws.once('message', message => {
-        t.assert.equal(message.toString(), `hello ${name}`)
+        t.assert.strictEqual(message.toString(), `hello ${name}`)
         // echo
         ws.send(message)
       })
@@ -100,7 +100,7 @@ test('multiple websocket upstreams', async (t) => {
     await once(ws, 'open')
     ws.send(`hello ${name}`)
     const [reply] = await once(ws, 'message')
-    t.assert.equal(reply.toString(), `hello ${name}`)
+    t.assert.strictEqual(reply.toString(), `hello ${name}`)
     wsClients.push(ws)
   }
 
@@ -135,8 +135,8 @@ test('getUpstream', async (t) => {
 
   const serverMessages = []
   wss.on('connection', (ws, request) => {
-    t.assert.equal(ws.protocol, subprotocolValue)
-    t.assert.equal(request.headers.cookie, cookieValue)
+    t.assert.strictEqual(ws.protocol, subprotocolValue)
+    t.assert.strictEqual(request.headers.cookie, cookieValue)
     ws.on('message', (message, binary) => {
       serverMessages.push([message.toString(), binary])
       // echo
@@ -157,8 +157,8 @@ test('getUpstream', async (t) => {
     upstream: '',
     replyOptions: {
       getUpstream: function (original) {
-        t.assert.notEqual(original, _req)
-        t.assert.equal(original.raw, _req)
+        t.assert.notStrictEqual(original, _req)
+        t.assert.strictEqual(original.raw, _req)
         return `http://127.0.0.1:${origin.address().port}`
       }
     },
@@ -174,13 +174,13 @@ test('getUpstream', async (t) => {
 
   ws.send('hello', { binary: false })
   const [reply0, binary0] = await once(ws, 'message')
-  t.assert.equal(reply0.toString(), 'hello')
-  t.assert.equal(binary0, false)
+  t.assert.strictEqual(reply0.toString(), 'hello')
+  t.assert.strictEqual(binary0, false)
 
   ws.send(Buffer.from('fastify'), { binary: true })
   const [reply1, binary1] = await once(ws, 'message')
-  t.assert.equal(reply1.toString(), 'fastify')
-  t.assert.equal(binary1, true)
+  t.assert.strictEqual(reply1.toString(), 'fastify')
+  t.assert.strictEqual(binary1, true)
 
   t.assert.deepStrictEqual(serverMessages, [
     ['hello', false],
@@ -203,8 +203,8 @@ test('getUpstream with unset wsUpstream', async (t) => {
 
   const serverMessages = []
   wss.on('connection', (ws, request) => {
-    t.assert.equal(ws.protocol, subprotocolValue)
-    t.assert.equal(request.headers.cookie, cookieValue)
+    t.assert.strictEqual(ws.protocol, subprotocolValue)
+    t.assert.strictEqual(request.headers.cookie, cookieValue)
     ws.on('message', (message, binary) => {
       serverMessages.push([message.toString(), binary])
       // echo
@@ -225,8 +225,8 @@ test('getUpstream with unset wsUpstream', async (t) => {
     wsUpstream: '',
     replyOptions: {
       getUpstream: function (original) {
-        t.assert.notEqual(original, _req)
-        t.assert.equal(original.raw, _req)
+        t.assert.notStrictEqual(original, _req)
+        t.assert.strictEqual(original.raw, _req)
         return `http://127.0.0.1:${origin.address().port}`
       }
     },
@@ -242,13 +242,13 @@ test('getUpstream with unset wsUpstream', async (t) => {
 
   ws.send('hello', { binary: false })
   const [reply0, binary0] = await once(ws, 'message')
-  t.assert.equal(reply0.toString(), 'hello')
-  t.assert.equal(binary0, false)
+  t.assert.strictEqual(reply0.toString(), 'hello')
+  t.assert.strictEqual(binary0, false)
 
   ws.send(Buffer.from('fastify'), { binary: true })
   const [reply1, binary1] = await once(ws, 'message')
-  t.assert.equal(reply1.toString(), 'fastify')
-  t.assert.equal(binary1, true)
+  t.assert.strictEqual(reply1.toString(), 'fastify')
+  t.assert.strictEqual(binary1, true)
 
   t.assert.deepStrictEqual(serverMessages, [
     ['hello', false],
@@ -271,8 +271,8 @@ test('websocket proxy trigger hooks', async (t) => {
 
   const serverMessages = []
   wss.on('connection', (ws, request) => {
-    t.assert.equal(ws.protocol, subprotocolValue)
-    t.assert.equal(request.headers.cookie, cookieValue)
+    t.assert.strictEqual(ws.protocol, subprotocolValue)
+    t.assert.strictEqual(request.headers.cookie, cookieValue)
     ws.on('message', (message, binary) => {
       serverMessages.push([message.toString(), binary])
       // echo
@@ -301,13 +301,13 @@ test('websocket proxy trigger hooks', async (t) => {
 
   ws.send('hello', { binary: false })
   const [reply0, binary0] = await once(ws, 'message')
-  t.assert.equal(reply0.toString(), 'hello')
-  t.assert.equal(binary0, false)
+  t.assert.strictEqual(reply0.toString(), 'hello')
+  t.assert.strictEqual(binary0, false)
 
   ws.send(Buffer.from('fastify'), { binary: true })
   const [reply1, binary1] = await once(ws, 'message')
-  t.assert.equal(reply1.toString(), 'fastify')
-  t.assert.equal(binary1, true)
+  t.assert.strictEqual(reply1.toString(), 'fastify')
+  t.assert.strictEqual(binary1, true)
 
   t.assert.deepStrictEqual(serverMessages, [
     ['hello', false],
@@ -330,8 +330,8 @@ test('websocket proxy with rewriteRequestHeaders', async (t) => {
 
   const serverMessages = []
   wss.on('connection', (ws, request) => {
-    t.assert.equal(ws.protocol, subprotocolValue)
-    t.assert.equal(request.headers.myauth, 'myauth')
+    t.assert.strictEqual(ws.protocol, subprotocolValue)
+    t.assert.strictEqual(request.headers.myauth, 'myauth')
     ws.on('message', (message, binary) => {
       serverMessages.push([message.toString(), binary])
       // echo
@@ -363,13 +363,13 @@ test('websocket proxy with rewriteRequestHeaders', async (t) => {
 
   ws.send('hello', { binary: false })
   const [reply0, binary0] = await once(ws, 'message')
-  t.assert.equal(reply0.toString(), 'hello')
-  t.assert.equal(binary0, false)
+  t.assert.strictEqual(reply0.toString(), 'hello')
+  t.assert.strictEqual(binary0, false)
 
   ws.send(Buffer.from('fastify'), { binary: true })
   const [reply1, binary1] = await once(ws, 'message')
-  t.assert.equal(reply1.toString(), 'fastify')
-  t.assert.equal(binary1, true)
+  t.assert.strictEqual(reply1.toString(), 'fastify')
+  t.assert.strictEqual(binary1, true)
 
   t.assert.deepStrictEqual(serverMessages, [
     ['hello', false],
@@ -392,8 +392,8 @@ test('websocket proxy custom headers', async (t) => {
 
   const serverMessages = []
   wss.on('connection', (ws, request) => {
-    t.assert.equal(ws.protocol, subprotocolValue)
-    t.assert.equal(request.headers.myauth, 'myauth')
+    t.assert.strictEqual(ws.protocol, subprotocolValue)
+    t.assert.strictEqual(request.headers.myauth, 'myauth')
     ws.on('message', (message, binary) => {
       serverMessages.push([message.toString(), binary])
       // echo
@@ -422,13 +422,13 @@ test('websocket proxy custom headers', async (t) => {
 
   ws.send('hello', { binary: false })
   const [reply0, binary0] = await once(ws, 'message')
-  t.assert.equal(reply0.toString(), 'hello')
-  t.assert.equal(binary0, false)
+  t.assert.strictEqual(reply0.toString(), 'hello')
+  t.assert.strictEqual(binary0, false)
 
   ws.send(Buffer.from('fastify'), { binary: true })
   const [reply1, binary1] = await once(ws, 'message')
-  t.assert.equal(reply1.toString(), 'fastify')
-  t.assert.equal(binary1, true)
+  t.assert.strictEqual(reply1.toString(), 'fastify')
+  t.assert.strictEqual(binary1, true)
 
   t.assert.deepStrictEqual(serverMessages, [
     ['hello', false],
@@ -461,7 +461,7 @@ test('Should gracefully close when clients attempt to connect after calling clos
     const ws = new WebSocket('ws://127.0.0.1:' + server.server.address().port)
 
     p = once(ws, 'unexpected-response').then(([_req, res]) => {
-      t.assert.equal(res.statusCode, 503)
+      t.assert.strictEqual(res.statusCode, 503)
       oldClose.call(this, cb)
     })
   }
@@ -527,8 +527,8 @@ test('Proxy websocket with custom upstream url', async (t) => {
 
     const [reply, binaryAnswer] = await once(ws, 'message')
 
-    t.assert.equal(reply.toString(), msg)
-    t.assert.equal(binaryAnswer, binary)
+    t.assert.strictEqual(reply.toString(), msg)
+    t.assert.strictEqual(binaryAnswer, binary)
   }
   // Also check "path", must be the same.
   t.assert.deepStrictEqual(serverMessages, [
@@ -596,8 +596,8 @@ test('Proxy websocket with custom upstream url', async (t) => {
 
     const [reply, binaryAnswer] = await once(ws, 'message')
 
-    t.assert.equal(reply.toString(), msg)
-    t.assert.equal(binaryAnswer, binary)
+    t.assert.strictEqual(reply.toString(), msg)
+    t.assert.strictEqual(binaryAnswer, binary)
   }
   // Also check "path", must be the same.
   t.assert.deepStrictEqual(serverMessages, [
@@ -624,7 +624,7 @@ test('multiple websocket upstreams with host constraints', async (t) => {
 
     wss.once('connection', (ws) => {
       ws.once('message', message => {
-        t.assert.equal(message.toString(), `hello ${name}`)
+        t.assert.strictEqual(message.toString(), `hello ${name}`)
         // echo
         ws.send(message)
       })
@@ -647,7 +647,7 @@ test('multiple websocket upstreams with host constraints', async (t) => {
     await once(ws, 'open')
     ws.send(`hello ${name}`)
     const [reply] = await once(ws, 'message')
-    t.assert.equal(reply.toString(), `hello ${name}`)
+    t.assert.strictEqual(reply.toString(), `hello ${name}`)
     wsClients.push(ws)
   }
 
@@ -669,7 +669,7 @@ test('multiple websocket upstreams with distinct server options', async (t) => {
     t.after(() => { origin.close() })
 
     wss.once('connection', (ws, req) => {
-      t.assert.equal(req.url, `/?q=${name}`)
+      t.assert.strictEqual(req.url, `/?q=${name}`)
       ws.once('message', message => {
         // echo
         ws.send(message)
@@ -683,7 +683,7 @@ test('multiple websocket upstreams with distinct server options', async (t) => {
       constraints: { host: name },
       wsServerOptions: {
         verifyClient: ({ req }) => {
-          t.assert.equal(req.url, `/?q=${name}`)
+          t.assert.strictEqual(req.url, `/?q=${name}`)
           return true
         }
       }

--- a/test/ws-prefix-rewrite-core.js
+++ b/test/ws-prefix-rewrite-core.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const t = require('tap')
+const test = require('node:test')
 const { once } = require('node:events')
 
 const Fastify = require('fastify')
@@ -22,8 +22,6 @@ async function proxyServer (t, backendURL, backendPath, proxyOptions, wrapperOpt
     })
   }
 
-  t.comment('starting proxy to ' + backendURL + backendPath)
-
   if (wrapperOptions) {
     await frontend.register(registerProxy, wrapperOptions)
   } else {
@@ -35,20 +33,18 @@ async function proxyServer (t, backendURL, backendPath, proxyOptions, wrapperOpt
 
 async function processRequest (t, frontendURL, path, expected) {
   const url = new URL(path, frontendURL)
-  t.comment('ws connecting to ' + url.toString())
   const wsUrl = convertUrlToWebSocket(url.href)
   const ws = new WebSocket(wsUrl)
   let wsResult, gotResult
 
   try {
     await once(ws, 'open')
-    t.pass('socket connected')
+    t.assert.ok('socket connected')
 
     const [buf] = await Promise.race([once(ws, 'message'), once(ws, 'close')])
     if (buf instanceof Buffer) {
       wsResult = buf.toString()
     } else {
-      t.comment('websocket closed')
       wsResult = 'error'
     }
   } catch {
@@ -63,12 +59,12 @@ async function processRequest (t, frontendURL, path, expected) {
     gotResult = 'error'
   }
 
-  t.equal(wsResult, expected)
-  t.equal(gotResult, expected)
+  t.assert.equal(wsResult, expected)
+  t.assert.equal(gotResult, expected)
 }
 
 async function handleProxy (info, { backendPath, proxyOptions, wrapperOptions }, expected, ...paths) {
-  t.test(info, async function (t) {
+  test(info, async function (t) {
     const backend = Fastify({ logger: { level } })
     await backend.register(fastifyWebSocket)
 
@@ -85,25 +81,21 @@ async function handleProxy (info, { backendPath, proxyOptions, wrapperOptions },
       }
     })
 
-    t.teardown(async () => {
+    t.after(async () => {
       await backend.close()
-      t.comment('backend closed')
     })
 
     const backendURL = await backend.listen({ port: 0, host: '127.0.0.1' })
 
     const [frontend, frontendURL] = await proxyServer(t, backendURL, backendPath, proxyOptions, wrapperOptions)
 
-    t.teardown(async () => {
+    t.after(async () => {
       await frontend.close()
-      t.comment('frontend closed')
     })
 
     for (const path of paths) {
       await processRequest(t, frontendURL, path, expected(path))
     }
-
-    t.end()
   })
 }
 

--- a/test/ws-prefix-rewrite-core.js
+++ b/test/ws-prefix-rewrite-core.js
@@ -59,8 +59,8 @@ async function processRequest (t, frontendURL, path, expected) {
     gotResult = 'error'
   }
 
-  t.assert.equal(wsResult, expected)
-  t.assert.equal(gotResult, expected)
+  t.assert.strictEqual(wsResult, expected)
+  t.assert.strictEqual(gotResult, expected)
 }
 
 async function handleProxy (info, { backendPath, proxyOptions, wrapperOptions }, expected, ...paths) {

--- a/test/ws-prefix-rewrite.js
+++ b/test/ws-prefix-rewrite.js
@@ -57,8 +57,8 @@ async function processRequest (t, frontendURL, path, expected) {
     gotResult = 'error'
   }
 
-  t.assert.equal(wsResult, expected)
-  t.assert.equal(gotResult, expected)
+  t.assert.strictEqual(wsResult, expected)
+  t.assert.strictEqual(gotResult, expected)
 }
 
 async function handleProxy (info, { backendPath, proxyOptions, wrapperOptions }, expected, ...paths) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

Moving the tests from `tap` to the node test runner, based on what requested in the following issue
[Fastify #5555](https://github.com/fastify/fastify/issues/5555)

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
