### PR TITLE
feat: Added fromParameters decorator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ The `context` object is passed to all hooks and contains the `log` property.
 
 ## Decorators
 
-## `reply.fromParameters(url[, params[, prefix]])`
+### `reply.fromParameters(url[, params[, prefix]])`
 
 It can be used to get the final URL and options that `@fastify/http-proxy` would have used to invoke `reply.from`.
 

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ preHandler (request, reply, done) {
     return
   }
 
-  const { url, options } = reply.fromParameters('/updated')
+  const { url, options } = reply.fromParameters('/updated', { ...request.params, serverId: 42 })
   reply.from(url, options)
 }
 ```

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ To enable the feature, set the `wsReconnect` option to an object with the follow
 
 See the example in [examples/reconnection](examples/reconnection).
 
-### wsHooks
+### `wsHooks`
 
 On websocket events, the following hooks are available, note **the hooks are all synchronous**.  
 The `context` object is passed to all hooks and contains the `log` property.

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ It also supports an additional `rewriteRequestHeaders(headers, request)` functio
 opening the WebSocket connection. This function should return an object with the given headers.
 The default implementation forwards the `cookie` header.
 
-## `wsReconnect`
+### `wsReconnect`
 
 **Experimental.** (default: `disabled`)
 
@@ -247,7 +247,7 @@ To enable the feature, set the `wsReconnect` option to an object with the follow
 
 See the example in [examples/reconnection](examples/reconnection).
 
-## wsHooks
+### wsHooks
 
 On websocket events, the following hooks are available, note **the hooks are all synchronous**.  
 The `context` object is passed to all hooks and contains the `log` property.
@@ -258,6 +258,26 @@ The `context` object is passed to all hooks and contains the `log` property.
 - `onDisconnect`: A hook function that is called when the connection is closed `onDisconnect(context, source)` (default: `undefined`).
 - `onReconnect`: A hook function that is called when the connection is reconnected `onReconnect(context, source, target)` (default: `undefined`). The function is called if reconnection feature is enabled.
 - `onPong`: A hook function that is called when the target responds to the ping `onPong(context, source, target)` (default: `undefined`). The function is called if reconnection feature is enabled.
+
+## Decorators
+
+## `reply.fromParameters(url[, params[, prefix]])`
+
+It can be used to get the final URL and options that `@fastify/http-proxy` would have used to invoke `reply.from`.
+
+A typical use is to override the request URL:
+
+```javascript
+preHandler (request, reply, done) {
+  if (request.url !== '/original') {
+    done()
+    return
+  }
+
+  const { url, options } = reply.fromParameters('/updated')
+  reply.from(url, options)
+}
+```
 
 ## Benchmarks
 


### PR DESCRIPTION
Adding support for the `fromParameters` decorator, which can be used to simulate a routing via fastify-http-proxy.

This is useful when you want to override the request URL.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
