### PR TITLE
feat: Add preRewrite and routes options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,12 @@ An array that contains the types of the methods. Default: `['DELETE', 'GET', 'HE
 
 An array that contains the routes to handle. Default: `['/', '/*']`.
 
+### `preRewrite`
+
+A function that will be executed before rewriting the URL. It receives the URL, the request parameters and the prefix and must return the new URL. 
+
+The function cannot return a promise.
+
 ### `websocket`
 
 This module has _partial_ support for forwarding websockets by passing a

--- a/README.md
+++ b/README.md
@@ -193,6 +193,10 @@ Note that the [rewriteHeaders](https://github.com/fastify/fastify-reply-from#rew
 
 An array that contains the types of the methods. Default: `['DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT', 'OPTIONS']`.
 
+### `routes`
+
+An array that contains the routes to handle. Default: `['/', '/*']`.
+
 ### `websocket`
 
 This module has _partial_ support for forwarding websockets by passing a

--- a/index.js
+++ b/index.js
@@ -83,6 +83,10 @@ function isExternalUrl (url) {
 
 function noop () { }
 
+function noopPreRewrite (url) {
+  return url
+}
+
 function createContext (logger) {
   return { log: logger }
 }
@@ -519,6 +523,7 @@ async function fastifyHttpProxy (fastify, opts) {
   opts = validateOptions(opts)
 
   const preHandler = opts.preHandler || opts.beforeHandler
+  const preRewrite = typeof opts.preRewrite === 'function' ? opts.preRewrite : noopPreRewrite
   const rewritePrefix = generateRewritePrefix(fastify.prefix, opts)
 
   const fromOpts = Object.assign({}, opts)
@@ -585,6 +590,8 @@ async function fastifyHttpProxy (fastify, opts) {
   }
 
   function fromParameters (url, params = {}, prefix = '/') {
+    url = preRewrite(url, params, prefix)
+
     const { path, queryParams } = extractUrlComponents(url)
     let dest = path
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ const fp = require('fastify-plugin')
 const qs = require('fast-querystring')
 const { validateOptions } = require('./src/options')
 
-const httpMethods = ['DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT', 'OPTIONS']
+const defaultRoutes = ['/', '/*']
+const defaultHttpMethods = ['DELETE', 'GET', 'HEAD', 'PATCH', 'POST', 'PUT', 'OPTIONS']
 const urlPattern = /^https?:\/\//
 const kWs = Symbol('ws')
 const kWsHead = Symbol('wsHead')
@@ -555,22 +556,13 @@ async function fastifyHttpProxy (fastify, opts) {
     done(null, payload)
   }
 
-  fastify.route({
-    url: '/',
-    method: opts.httpMethods || httpMethods,
-    preHandler,
-    config: opts.config || {},
-    constraints: opts.constraints || {},
-    handler
-  })
-  fastify.route({
-    url: '/*',
-    method: opts.httpMethods || httpMethods,
-    preHandler,
-    config: opts.config || {},
-    constraints: opts.constraints || {},
-    handler
-  })
+  const method = opts.httpMethods || defaultHttpMethods
+  const config = opts.config || {}
+  const constraints = opts.constraints || {}
+
+  for (const url of opts.routes || defaultRoutes) {
+    fastify.route({ url, method, preHandler, config, constraints, handler })
+  }
 
   let wsProxy
 
@@ -646,4 +638,6 @@ module.exports = fp(fastifyHttpProxy, {
   encapsulate: true
 })
 module.exports.default = fastifyHttpProxy
+module.exports.defaultRoutes = defaultRoutes
+module.exports.defaultHttpMethods = defaultHttpMethods
 module.exports.fastifyHttpProxy = fastifyHttpProxy

--- a/test/test.js
+++ b/test/test.js
@@ -981,6 +981,30 @@ async function run () {
       t.assert.strictEqual(body, 'this is a')
     }
   })
+
+  test('preRewrite handler', async t => {
+    const proxyServer = Fastify()
+
+    proxyServer.register(proxy, {
+      upstream: `http://localhost:${origin.server.address().port}`,
+      prefix: '/api',
+      rewritePrefix: '/api2/',
+      preRewrite (url) {
+        return url.replace('abc', 'a')
+      }
+    })
+
+    await proxyServer.listen({ port: 0 })
+
+    t.after(() => {
+      proxyServer.close()
+    })
+
+    const firstProxyPrefix = await got(
+      `http://localhost:${proxyServer.server.address().port}/api/abc`
+    )
+    t.assert.strictEqual(firstProxyPrefix.body, 'this is /api2/a')
+  })
 }
 
 run()

--- a/test/test.js
+++ b/test/test.js
@@ -989,7 +989,11 @@ async function run () {
       upstream: `http://localhost:${origin.server.address().port}`,
       prefix: '/api',
       rewritePrefix: '/api2/',
-      preRewrite (url) {
+      preRewrite (url, params, prefix) {
+        t.assert.strictEqual(url, '/api/abc')
+        t.assert.ok(typeof params, 'object')
+        t.assert.strictEqual(params['*'], 'abc')
+        t.assert.strictEqual(prefix, '/api')
         return url.replace('abc', 'a')
       }
     })

--- a/test/test.js
+++ b/test/test.js
@@ -751,6 +751,29 @@ async function run () {
     t.assert.fail()
   })
 
+  test('settings of routes', async t => {
+    const server = Fastify()
+    server.register(proxy, {
+      upstream: `http://localhost:${origin.server.address().port}`,
+      routes: ['/a']
+    })
+
+    await server.listen({ port: 0 })
+    t.after(() => server.close())
+
+    const resultRoot = await got(`http://localhost:${server.server.address().port}/a`)
+    t.assert.deepStrictEqual(resultRoot.statusCode, 200)
+
+    let errored = false
+    try {
+      await await got(`http://localhost:${server.server.address().port}/api2/a`)
+    } catch (err) {
+      t.assert.strictEqual(err.response.statusCode, 404)
+      errored = true
+    }
+    t.assert.ok(errored)
+  })
+
   test('settings of method types', async t => {
     const server = Fastify()
     server.register(proxy, {


### PR DESCRIPTION
This PR adds two new options:

1. `routes`, which is used to explicitly provide the list of routes we want to manage via `http-proxy`. Defaults to `/` and `/*`, which is the current behavior.
2. `preRewrite`, which is a function which can be provided to manipulate the request URL before rewriting and serving it via `reply.from`.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
