### PR TITLE
Allow `upstream` to be `undici.BalancedPool`, pass `maxRetriesOn503` to `replyOpts`

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ be streamed directly to the destination._
 
 An URL (including protocol) that represents the target server to use for proxying.
 
+It can be an array of URLs, if you want to use [`undici.BalancedPool`](https://undici.nodejs.org/#/docs/api/BalancedPool) (`upstream` is compatible with  [`base`](https://github.com/fastify/fastify-reply-from?tab=readme-ov-file#base) option).
+
 ### `prefix`
 
 The prefix to mount this plugin on. All the requests to the current server starting with the given prefix will be proxied to the provided upstream.

--- a/index.js
+++ b/index.js
@@ -532,8 +532,10 @@ async function fastifyHttpProxy (fastify, opts) {
 
   const internalRewriteLocationHeader = opts.internalRewriteLocationHeader ?? true
   const oldRewriteHeaders = (opts.replyOptions || {}).rewriteHeaders
+  const maxRetriesOn503 = opts.maxRetriesOn503
   const replyOpts = Object.assign({}, opts.replyOptions, {
-    rewriteHeaders
+    rewriteHeaders,
+    maxRetriesOn503
   })
   fromOpts.rewriteHeaders = rewriteHeaders
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -60,7 +60,7 @@ declare namespace fastifyHttpProxy {
   ) => string
 
   export interface FastifyHttpProxyOptions extends FastifyReplyFromOptions {
-    upstream: string;
+    upstream: string | string[];
     prefix?: string;
     rewritePrefix?: string;
     proxyPayloads?: boolean;


### PR DESCRIPTION
Change `upstream` type to be compatible with `base`, based on assumption from [`fromOpts.base = opts.upstream`](https://github.com/fastify/fastify-http-proxy/blob/main/index.js#L530) (https://github.com/fastify/fastify-http-proxy/pull/279#discussion_r2266903707).
Pass `maxRetriesOn503` to `replyOpts`, which is not part of `FastifyReplyFromOptions`, but is expected to be on this level (https://github.com/fastify/fastify-http-proxy/pull/34#discussion_r2262658638).

https://github.com/fastify/fastify-http-proxy/pull/34#discussion_r2262658638

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
