### PR TITLE
chore: address security scanner false positives related to `CVE-2023-2968`

### DIFF
--- a/examples/reconnection/proxy/package.json
+++ b/examples/reconnection/proxy/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "proxy",
+  "name": "fastify-http-proxy-reconnection-proxy-exapmle",
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {

--- a/examples/reconnection/proxy/package.json
+++ b/examples/reconnection/proxy/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fastify-http-proxy-reconnection-proxy-exapmle",
+  "name": "fastify-http-proxy-reconnection-proxy-example",
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Hi there! 👋 

First off, great library, we use this over in [`archestra-ai/archestra`](https://github.com/archestra-ai/archestra). 

Docker Scout security scans seem to pick-up `v11.3.0` of this library as a false-positive for [CVE-2023-2968](https://nvd.nist.gov/vuln/detail/CVE-2023-2968):

<img width="2802" height="1738" alt="Screenshot 2025-11-26 at 11 50 35 AM" src="https://github.com/user-attachments/assets/a68325b4-c082-40b4-835b-0ac2767bb9bc" />

(see "Package location" path under the first vulnerability in my screenshot).

I _think_ by simply renaming the `name` of `examples/reconnection/proxy/package.json` that should address that?

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present` (N/A)
- [x] tests and/or benchmarks are included (N/A)
- [x] documentation is changed or added (N/A)
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
