### PR TITLE
fix(qs): preserve fromParameters query params

### DIFF
--- a/index.js
+++ b/index.js
@@ -605,11 +605,12 @@ async function fastifyHttpProxy (fastify, opts) {
       }
 
       dest = dest.replace(prefixPathWithVariables, rewritePrefixWithVariables)
-      if (queryParams) {
-        dest += `?${qs.stringify(queryParams)}`
-      }
     } else {
       dest = dest.replace(prefix, rewritePrefix)
+    }
+
+    if (queryParams) {
+      dest += `?${qs.stringify(queryParams)}`
     }
 
     return { url: dest || '/', options: replyOpts }
@@ -617,17 +618,18 @@ async function fastifyHttpProxy (fastify, opts) {
 
   function handler (request, reply) {
     const { url, options } = fromParameters(request.url, request.params, this.prefix)
+    const dest = url.split('?')[0]
 
     if (request.raw[kWs]) {
       reply.hijack()
       try {
-        wsProxy.handleUpgrade(request, url, noop)
+        wsProxy.handleUpgrade(request, dest, noop)
       } /* c8 ignore start */ catch (err) {
         request.log.warn({ err }, 'websocket proxy error')
       } /* c8 ignore stop */
       return
     }
-    reply.from(url, options)
+    reply.from(dest, options)
   }
 
   fastify.decorateReply('fromParameters', fromParameters)

--- a/index.js
+++ b/index.js
@@ -618,7 +618,7 @@ async function fastifyHttpProxy (fastify, opts) {
 
   function handler (request, reply) {
     const { url, options } = fromParameters(request.url, request.params, this.prefix)
-    const dest = url.split('?')[0]
+    const dest = url.split('?', 1)[0]
 
     if (request.raw[kWs]) {
       reply.hijack()

--- a/test/test.js
+++ b/test/test.js
@@ -38,6 +38,10 @@ async function run () {
     return 'this is /api2/a'
   })
 
+  origin.get('/api2/echo-query', async (request) => {
+    return `query: ${JSON.stringify(request.query)}`
+  })
+
   origin.get('/variable-api/:id/endpoint', async (request) => {
     return `this is "variable-api" endpoint with id ${request.params.id}`
   })
@@ -898,6 +902,27 @@ async function run () {
       t.assert.strictEqual(response.status, 200)
       t.assert.strictEqual(body, 'this is a')
     }
+  })
+
+  test('fromParameters should preserve query params with non-parameterized prefix', async t => {
+    let fromParametersUrl
+    const server = Fastify()
+    server.register(proxy, {
+      upstream: `http://localhost:${origin.server.address().port}`,
+      prefix: '/api',
+      rewritePrefix: '/api2',
+      preHandler (request, reply, done) {
+        const { url } = reply.fromParameters(request.url, request.params, '/api')
+        fromParametersUrl = url
+        done()
+      }
+    })
+
+    await server.listen({ port: 0 })
+    t.after(() => server.close())
+
+    await fetch(`http://localhost:${server.server.address().port}/api/echo-query?foo=bar&baz=qux`)
+    t.assert.strictEqual(fromParametersUrl, '/api2/echo-query?foo=bar&baz=qux')
   })
 
   test('preRewrite handler', async t => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Fixes #450

Let `fromParameters` preserving query params with non-parameterized prefix

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
