### PR TITLE
docs: fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This [`fastify`](https://fastify.dev) plugin forwards all requests
 received with a given prefix (or none) to an upstream. All Fastify hooks are still applied.
 
 `@fastify/http-proxy` is built on top of
-[`@fastify/reply-from`](https://npm.im/@fastify/reply-from), which enables single route proxying.
+[`@fastify/reply-from`](https://www.npmjs.com/package/@fastify/reply-from), which enables single route proxying.
 
 This plugin can be used in a variety of circumstances, for example, if you have to proxy an internal domain to an external domain (useful to avoid CORS problems) or to implement your own API gateway for a microservices architecture.
 


### PR DESCRIPTION
Fixes 404s, 3xx redirections, and missing fragments in the documentation. Part of general link cleanup being tracked in https://github.com/fastify/accept-negotiator/pull/71