### PR TITLE
fix: sanitize invalid characters in proxied response headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const { setTimeout: wait } = require('node:timers/promises')
 const From = require('@fastify/reply-from')
 const { ServerResponse } = require('node:http')
 const WebSocket = require('ws')
-const { convertUrlToWebSocket } = require('./utils')
+const { convertUrlToWebSocket, sanitizeHeaders } = require('./utils')
 const fp = require('fastify-plugin')
 const qs = require('fast-querystring')
 const { validateOptions } = require('./src/options')
@@ -558,6 +558,11 @@ async function fastifyHttpProxy (fastify, opts) {
     if (oldRewriteHeaders) {
       headers = oldRewriteHeaders(headers, req)
     }
+
+    // Sanitize header values so an upstream reply with an invalid header
+    // does not crash the whole request.
+    headers = sanitizeHeaders(headers)
+
     return headers
   }
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { test } = require('node:test')
-const { convertUrlToWebSocket } = require('../utils')
+const { convertUrlToWebSocket, sanitizeHeaderValue, sanitizeHeaders } = require('../utils')
 
 test('convertUrlToWebSocket', function (t) {
   const testData = [
@@ -17,4 +17,31 @@ test('convertUrlToWebSocket', function (t) {
   for (const { input, expected } of testData) {
     t.assert.strictEqual(convertUrlToWebSocket(input), expected)
   }
+})
+
+test('sanitizeHeaderValue', function (t) {
+  const testData = [
+    { input: 'application/json', expected: 'application/json' },
+    { input: 'a\tb', expected: 'a\tb' },
+    { input: 'café', expected: 'café' },
+    { input: 'a\x01b', expected: 'ab' },
+    { input: 'hi😀there', expected: 'hithere' },
+    { input: '€9', expected: '9' }
+  ]
+  t.plan(testData.length)
+  for (const { input, expected } of testData) {
+    t.assert.strictEqual(sanitizeHeaderValue(input), expected)
+  }
+})
+
+test('sanitizeHeaders', function (t) {
+  t.plan(3)
+  // string values are sanitized; array values (e.g. set-cookie) map element-wise;
+  // non-string values (numbers, non-string array items) are left untouched.
+  t.assert.deepStrictEqual(
+    sanitizeHeaders({ 'content-type': 'text/html😀', 'set-cookie': ['a=1\x01', 'b=2'] }),
+    { 'content-type': 'text/html', 'set-cookie': ['a=1', 'b=2'] }
+  )
+  t.assert.deepStrictEqual(sanitizeHeaders({ 'content-length': 42 }), { 'content-length': 42 })
+  t.assert.deepStrictEqual(sanitizeHeaders({ mixed: ['x\x01', 7] }), { mixed: ['x', 7] })
 })

--- a/utils.js
+++ b/utils.js
@@ -4,6 +4,29 @@ function convertUrlToWebSocket (urlString) {
   return urlString.replace(/^(http)(s)?:\/\//, 'ws$2://')
 }
 
+// Strip characters that are not valid in an HTTP header value, so proxying a
+// reply with an invalid upstream header does not throw.
+// Allowed: HTAB (0x09), SP (0x20)-~ (0x7E), and obs-text (0x80-0xFF).
+function sanitizeHeaderValue (value) {
+  return value.replace(/[^\t\x20-\x7E\x80-\xFF]/g, '')
+}
+
+// Sanitize every header value in place. Values may be strings or arrays of
+// strings (e.g. set-cookie); anything else is left untouched.
+function sanitizeHeaders (headers) {
+  for (const key in headers) {
+    const value = headers[key]
+    if (typeof value === 'string') {
+      headers[key] = sanitizeHeaderValue(value)
+    } else if (Array.isArray(value)) {
+      headers[key] = value.map((v) => (typeof v === 'string' ? sanitizeHeaderValue(v) : v))
+    }
+  }
+  return headers
+}
+
 module.exports = {
-  convertUrlToWebSocket
+  convertUrlToWebSocket,
+  sanitizeHeaderValue,
+  sanitizeHeaders
 }


### PR DESCRIPTION
## Description

When proxying, an upstream response can include a header whose value contains characters that are invalid in an outgoing HTTP header — control characters, or code points above `0xFF` (e.g. an emoji or certain Unicode characters a service put in a header). Copying such a value onto the downstream reply makes Node throw `Invalid character in header content [...]`, which fails the **entire** proxied request rather than just the offending header.

This sanitizes response header values inside `rewriteHeaders` before they are set downstream. Values outside the set allowed by RFC 7230 field-content — HTAB (`0x09`), visible ASCII/space (`0x20`–`0x7E`), and obs-text (`0x80`–`0xFF`) — are stripped, so a bad upstream header degrades gracefully instead of taking down the request. Both string values and array values (e.g. `set-cookie`) are handled.

Closes #343

## How Has This Been Tested?

- Added unit tests for the two new `utils` helpers:
  - `sanitizeHeaderValue` — keeps normal values, tab, and obs-text; strips control characters, high-Unicode characters, and code points above `0xFF`.
  - `sanitizeHeaders` — sanitizes string and array header values, leaving non-string values untouched.
- Full suite passes locally with `npm test` (lint + tests + 100% coverage + TypeScript).

## Checklist

- [x] I have read CONTRIBUTING.md
- [x] I have added unit tests
- [x] `npm test` passes (lint, tests, coverage, types)
