### PR TITLE
test: cover falsy dynamic upstream fallback

### DIFF
--- a/test/http-prefix-rewrite.js
+++ b/test/http-prefix-rewrite.js
@@ -150,3 +150,34 @@ test('reply.fromParameters cannot escape rewritePrefix', async t => {
   t.assert.strictEqual(regular.statusCode, 200)
   t.assert.strictEqual(regular.body, 'internal:/internal/foo')
 })
+
+test('HTTP request with a falsy dynamic upstream falls back to the default validation host', async t => {
+  const backend = Fastify()
+  const frontend = Fastify()
+
+  t.after(async () => {
+    await frontend.close()
+    await backend.close()
+  })
+
+  backend.get('/internal/*', request => `internal:${request.url}`)
+  await backend.listen({ port: 0, host: '127.0.0.1' })
+
+  frontend.register(proxy, {
+    upstream: '',
+    prefix: '/pub',
+    rewritePrefix: '/internal',
+    replyOptions: {
+      // Keep upstream falsy after getUpstream()
+      getUpstream () {
+        return ''
+      }
+    }
+  })
+  await frontend.listen({ port: 0, host: '127.0.0.1' })
+
+  const port = frontend.server.address().port
+  const response = await request(port, '/pub/foo')
+
+  t.assert.strictEqual(response.statusCode, 500)
+})


### PR DESCRIPTION
Proposal:

- Adds a test case for a falsy dynamic upstream in `resolveDestination()`. The test covers the `upstream || undefined` fallback when `getUpstream()` returns an empty string.
- Fix CI ( see here: https://github.com/fastify/fastify-http-proxy/actions/runs/33734142076/job/100580755388#step:5:162 )

--- 
Screenshot test coverage:


before:

<img width="916" height="265" alt="Screenshot 2026-09-03 alle 17 42 37" src="https://github.com/user-attachments/assets/28f329bf-b7ad-4134-ad75-69e043ba0a90" />

after:

<img width="864" height="209" alt="Screenshot 2026-09-03 alle 17 43 37" src="https://github.com/user-attachments/assets/549b2fd6-9e92-4448-80e9-1b992f39d889" />

---

Note:

- Test Coverage remains at 100% 🙌

